### PR TITLE
Relaxing rails/ar version constraint to ~>3.1 instead of ~>3.1.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,29 +2,29 @@ PATH
   remote: .
   specs:
     temping (2.0.4)
-      activerecord (~> 3.1.1)
-      activesupport (~> 3.1.1)
+      activerecord (~> 3.1)
+      activesupport (~> 3.1)
       sqlite3 (~> 1.3.4)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    activemodel (3.1.1)
-      activesupport (= 3.1.1)
+    activemodel (3.2.9)
+      activesupport (= 3.2.9)
       builder (~> 3.0.0)
-      i18n (~> 0.6)
-    activerecord (3.1.1)
-      activemodel (= 3.1.1)
-      activesupport (= 3.1.1)
-      arel (~> 2.2.1)
+    activerecord (3.2.9)
+      activemodel (= 3.2.9)
+      activesupport (= 3.2.9)
+      arel (~> 3.0.2)
       tzinfo (~> 0.3.29)
-    activesupport (3.1.1)
+    activesupport (3.2.9)
+      i18n (~> 0.6)
       multi_json (~> 1.0)
-    arel (2.2.1)
-    builder (3.0.0)
+    arel (3.0.2)
+    builder (3.0.4)
     diff-lcs (1.1.3)
-    i18n (0.6.0)
-    multi_json (1.0.3)
+    i18n (0.6.1)
+    multi_json (1.4.0)
     rspec (2.7.0)
       rspec-core (~> 2.7.0)
       rspec-expectations (~> 2.7.0)
@@ -33,8 +33,8 @@ GEM
     rspec-expectations (2.7.0)
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.7.0)
-    sqlite3 (1.3.4)
-    tzinfo (0.3.31)
+    sqlite3 (1.3.6)
+    tzinfo (0.3.35)
 
 PLATFORMS
   ruby

--- a/temping.gemspec
+++ b/temping.gemspec
@@ -12,8 +12,8 @@ Gem::Specification.new do |s|
 
   s.files = ["lib/temping.rb", "lib/version.rb"]
 
-  s.add_dependency "activerecord", "~> 3.1.1"
-  s.add_dependency "activesupport", "~> 3.1.1"
+  s.add_dependency "activerecord", "~> 3.1"
+  s.add_dependency "activesupport", "~> 3.1"
   s.add_dependency "sqlite3", "~> 1.3.4"
 
   s.add_development_dependency "rspec", "~> 2.7.0"


### PR DESCRIPTION
Hey John,

Thanks for this gem. It's super helpful. This commit simply makes it 3.2.x compatible. I've re-run the specs, and they pass.

Thanks,
Chris
