### PR TITLE
Allow to change DB connection options.

### DIFF
--- a/lib/temping.rb
+++ b/lib/temping.rb
@@ -4,11 +4,15 @@ require "active_support/core_ext/string"
 class Temping
   def self.create(model_name, &block)
     unless ActiveRecord::Base.connected?
-      ActiveRecord::Base.establish_connection("sqlite3:///:memory:")
+      ActiveRecord::Base.establish_connection(database_connection)
     end
 
     factory = ModelFactory.new(model_name.to_s.classify, &block)
     factory.klass
+  end
+
+  def self.database_connection
+    "sqlite3:///:memory:"
   end
 
   class ModelFactory


### PR DESCRIPTION
There was an issue if Temping established the connection before any app
model. Depending on the setup, all tests could end up
looking for tables at sqlite3 in-memory db, and raised many errors about
those tables not existing.

This change lets the user configure any custom DB connection setting
by overriding `Temping.database_connection`.
