### PR TITLE
Don't hijack ActiveRecord::Base connection

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    temping (3.0.2)
+    temping (3.2.0)
       activerecord (>= 3.1)
       activesupport (>= 3.1)
       sqlite3 (~> 1.3.7)
@@ -24,7 +24,7 @@ GEM
     builder (3.0.4)
     diff-lcs (1.2.4)
     i18n (0.6.1)
-    multi_json (1.7.2)
+    multi_json (1.7.3)
     rake (10.0.4)
     rspec (2.13.0)
       rspec-core (~> 2.13.0)

--- a/README.md
+++ b/README.md
@@ -7,11 +7,8 @@ SQL table for use in tests. You may need to do something like this if you're
 testing a module that is meant to be mixed into ActiveReord models without
 relaying on a concrete class.
 
-Temping will use your existing database connection. If one does not exist,
-it will create and connect to an in-memory SQLite3 instance.
-
-As we're using temporary tables all data will be dropped when the database
-connection is terminated.
+Temping will use your existing database connection. As we're using temporary
+tables all data will be dropped when the database connection is terminated.
 
 ## Examples
 

--- a/lib/temping.rb
+++ b/lib/temping.rb
@@ -3,10 +3,6 @@ require "active_support/core_ext/string"
 
 class Temping
   def self.create(model_name, &block)
-    unless ActiveRecord::Base.connected?
-      ActiveRecord::Base.establish_connection("sqlite3:///:memory:")
-    end
-
     factory = ModelFactory.new(model_name.to_s.classify, &block)
     factory.klass
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,3 +2,5 @@ $: << File.join(File.dirname(__FILE__), "/../lib")
 
 require "bundler/setup"
 require "temping"
+
+ActiveRecord::Base.establish_connection("sqlite3:///:memory:")

--- a/temping.gemspec
+++ b/temping.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "temping"
-  s.version     = "3.1.0"
+  s.version     = "3.2.0"
   s.authors     = ["John Pignata"]
   s.email       = "john@pignata.com"
   s.homepage    = "http://github.com/jpignata/temping"


### PR DESCRIPTION
The default of a sqlite in-memory database is somewhat presumptuous.
It was causing some trouble in the latest release where it would
attempt to connect to sqlite even though the it was already connected
to another database.

Rather than trying to get it to be more polite, I'm going to remove it
entirely. It's doing more harm than good if you have to worry about your
your ActiveRecord connection being hijacked depending on your test run
order.
