### PR TITLE
Add Temping::teardown

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,18 @@ In your Gemfile:
 gem "temping"
 ```
 
+In `test_helper.rb` add the following block to `ActiveSupport::TestCase`:
+
+```ruby
+class ActiveSupport::TestCase
+  # ...
+  teardown do
+    Temping.teardown
+  end
+  # ...
+end
+```
+
 ## Bugs, Features, Feedback
 
 Tickets can be submitted by via GitHub issues.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,3 +4,45 @@ require "bundler/setup"
 require "temping"
 
 ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+
+# The #temporary_table_exists? is required by the spec. The implementation
+# provided by Rails doesn't work for temporary tables in SQLite as they are not
+# visible in sqlite_master. sqlite_temp_master is the right table to query. An
+# alternative method of finding out whether a temporary table is defined would
+# be a call to columns - it raises an exception when the table is not defined.
+# However, this approach makes writing the expectation more difficult as
+# expecting an exception is too general (we can swallow exceptions signaling a
+# real problem).
+#
+# For other adapters we just alias #temporary_tables and
+# #temporary_table_exists? to #tables and #table_exists? respectively.
+module ActiveRecord::ConnectionAdapters
+  class AbstractAdapter
+    def temporary_tables(name, table_name)
+      tables(name, table_name)
+    end
+
+    def temporary_table_exists?(table_name)
+      table_exists?(table_name)
+    end
+  end
+
+  class SQLite3Adapter
+    def temporary_tables(name = nil, table_name = nil) #:nodoc:
+      sql = <<-SQL
+              SELECT name
+              FROM sqlite_temp_master
+              WHERE (type = 'table' OR type = 'view') AND NOT name = 'sqlite_sequence'
+      SQL
+      sql << " AND name = #{quote_table_name(table_name)}" if table_name
+
+      exec_query(sql, 'SCHEMA').map do |row|
+        row['name']
+      end
+    end
+
+    def temporary_table_exists?(table_name)
+      table_name && temporary_tables(nil, table_name).any?
+    end
+  end
+end

--- a/spec/temping_spec.rb
+++ b/spec/temping_spec.rb
@@ -50,5 +50,25 @@ describe Temping do
         Comment.columns.map(&:name).should include("count", "headline", "body")
       end
     end
+
+    describe ".teardown" do
+      it "undefines the models" do
+        Temping.create :user do
+          with_columns do |table|
+            table.string :email
+          end
+        end
+
+        # Store the connection because a call to teardown will undefine the
+        # User model.
+        connection = User.connection
+
+        Temping.teardown
+
+        connection.temporary_table_exists?(:users).should be_false
+        Object.const_defined?(:User).should be_false
+      end
+    end
+
   end
 end


### PR DESCRIPTION
# Overview

I added `Temping::teardown` in order to solve #18. This method drops all tables and undefines all constants introduced by Temping. It's now possible to use Temping in `setup`/`before` blocks.

The change is fully backward compatible. If `Temping::teardown` is not called the code behaves exactly as before.

I had to introduce a monkey patch (d'oh!) in the spec helper in order to write an expectation. `#table_exists?` offered by Active Record (at least the SQLite adapter) does _not_ work for temporary tables. See the comment above the monkey patch for more details.

# Commit Message
`teardown` should be called from `teardown`/`after` blocks in order to clean up tables and objects created by Temping. Without it it's not possible to use Temping in a `setup`/`before` block and reuse the same temporary model in multiple tests.

Fix #18.