### PR TITLE
Add automated multi-database tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,6 @@ rvm:
   - 2.1
   - 2.0
   - 1.9
+before_script:
+  - bundle exec rake db:mysql:create
+  - bundle exec rake db:postgresql:create

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+Want to contribute to the development of temping! Great! Here's what you can do:
+
+* suggest a feature or submit a bug at https://github.com/jpignata/temping/issues
+* contribute code or documentation by submitting a pull request at https://github.com/jpignata/temping/pulls
+
+If you submit code make sure that the test suite is still green. The code is
+currently tested against SQLite3, PostgreSQL and MySQL. Before running the test
+suite against each of these databases you must perform a bit of setup:
+
+```
+$ rake db:postgresql:create # to set up PostgreSQL
+$ rake db:mysql:create # to set up MySQL
+```
+
+The configuration used to access the databases is stored in
+`spec/config.default.yml`. After running these commands you can run the test
+suite with `rake`. If you want to test a particular database adapter run
+`rake spec:<adapter name>`, e.g. `rake spec:mysql`.
+
+If, for any reason, you want to recreate the test databases you can do so by
+running `rake db:postgresql:drop db:mysql:drop`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,9 @@ GEM
     i18n (0.7.0)
     json (1.8.2)
     minitest (5.6.1)
+    mysql (2.9.1)
+    mysql2 (0.3.18)
+    pg (0.18.2)
     rake (10.0.4)
     rspec (2.13.0)
       rspec-core (~> 2.13.0)
@@ -45,6 +48,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  mysql (~> 2.9.1)
+  mysql2 (~> 0.3.18)
+  pg (~> 0.18.2)
   rake (>= 10.0.4)
   rspec (>= 2.13.0)
   sqlite3 (~> 1.3.10)

--- a/README.md
+++ b/README.md
@@ -96,4 +96,5 @@ end
 
 ## Bugs, Features, Feedback
 
-Tickets can be submitted by via GitHub issues.
+All contributions are welcome! Please take a look at `CONTRIBUTING.md` for some
+tips.

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,38 @@
 require 'rspec/core/rake_task'
+require_relative 'spec/test_config'
 
 task :default => [:spec]
 
-RSpec::Core::RakeTask.new(:spec) do |spec|
-  spec.rspec_opts = '--colour'
+task :spec => TestConfig.adapters.map { |adapter| "spec:#{adapter}"}
+
+TestConfig.adapters.each do |adapter|
+  namespace :spec do
+    RSpec::Core::RakeTask.new(adapter) do |spec|
+      puts "Testing adapter #{adapter}\n\n"
+      TestConfig.current_adapter = adapter
+      spec.rspec_opts = '--colour'
+    end
+  end
+end
+
+namespace :db do
+  namespace :postgresql do
+    task :create do
+      %x(createdb -E UTF8 -T template0 #{TestConfig['postgresql']['database']})
+    end
+
+    task :drop do
+      %x(dropdb #{TestConfig['postgresql']['database']})
+    end
+  end
+
+  namespace :mysql do
+    task :create do
+      %x(mysql --user=#{TestConfig['mysql']['username']} --execute="CREATE DATABASE #{TestConfig['mysql']['database']} DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci")
+    end
+
+    task :drop do
+      %x(mysql --user=#{TestConfig['mysql']['username']} --execute="DROP DATABASE #{TestConfig['mysql']['database']}")
+    end
+  end
 end

--- a/spec/config.default.yml
+++ b/spec/config.default.yml
@@ -1,0 +1,13 @@
+sqlite3:
+  database: ":memory:"
+
+postgresql:
+  database: temping_test
+
+mysql:
+  database: temping_test
+  username: root
+
+mysql2:
+  database: temping_test
+  username: root

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,18 @@
 $: << File.join(File.dirname(__FILE__), "/../lib")
 
 require "bundler/setup"
+require_relative 'test_config'
 require "temping"
 
-ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+RSpec.configure do |config|
+  config.before(:suite) do
+    ActiveRecord::Base.establish_connection(TestConfig.current_config)
+  end
+
+  config.after(:suite) do
+    ActiveRecord::Base.remove_connection
+  end
+end
 
 # The #temporary_table_exists? is required by the spec. The implementation
 # provided by Rails doesn't work for temporary tables in SQLite as they are not
@@ -27,7 +36,7 @@ module ActiveRecord::ConnectionAdapters
     end
   end
 
-  class SQLite3Adapter
+  class SQLite3Adapter < AbstractAdapter
     def temporary_tables(name = nil, table_name = nil) #:nodoc:
       sql = <<-SQL
               SELECT name

--- a/spec/test_config.rb
+++ b/spec/test_config.rb
@@ -1,0 +1,48 @@
+require 'yaml'
+
+module TestConfig
+  class << self
+    def current_config
+      self[current_adapter]
+    end
+
+    def [](adapter_name)
+      config[adapter_name] || fail("the adapter '#{adapter_name}' is not configured")
+    end
+
+    def adapters
+      config.keys
+    end
+
+    # #current_adapter and #current_adapter= use an environment variable because
+    # the value must be passed to a child process. When a test suite is run by
+    # executing +rake+ a Ruby process is started. +RSpec::Core::RakeTask+ runs
+    # +spec+ in a Ruby child process. The adapter is chosen by the parent
+    # process but tested by the child process. Using an environment variable is
+    # the simplest way of passing a value from the parent to the child.
+    def current_adapter
+      ENV.fetch('TEMPING_ADAPTER')
+    end
+
+    def current_adapter=(current_adapter)
+      ENV['TEMPING_ADAPTER'] = current_adapter
+    end
+
+    private
+
+    def config
+      @config ||=
+          begin
+            config = YAML.load(File.read(config_path))
+            config.keys.each do |adapter|
+              config[adapter]['adapter'] = adapter
+            end
+            config
+          end
+    end
+
+    def config_path
+      File.join(File.dirname(__FILE__), 'config.default.yml')
+    end
+  end
+end

--- a/temping.gemspec
+++ b/temping.gemspec
@@ -15,6 +15,9 @@ Gem::Specification.new do |s|
     s.add_development_dependency "activerecord-jdbcsqlite3-adapter", "~> 1.2.9"
   else
     s.add_development_dependency "sqlite3", "~> 1.3.10"
+    s.add_development_dependency "pg", "~> 0.18.2"
+    s.add_development_dependency "mysql", "~> 2.9.1"
+    s.add_development_dependency "mysql2", "~> 0.3.18"
   end
 
   s.add_development_dependency "rspec", ">= 2.13.0"


### PR DESCRIPTION
# Overview

I implemented a simple multi-database test mechanism (inspired by [Active Record test tasks](https://github.com/rails/rails/blob/master/activerecord/Rakefile)). The adapters are configured in `spec/config.default.yml`. Before running the tests, a one-time setup is required:

```
$ rake db:mysql:create db:postgresql:create
```

The credentials that are used to create the database are specified in `spec/config.default.yml`. After the databases are created you can run the specs like:

```
$ rake # or rake spec - runs the specs against all adapters
$ rake spec:mysql
$ rake spec:postgresql
$ rake spec:sqlite3
```

[The Travis build](https://travis-ci.org/grn/temping) was successful.

# Rationale

Configuration logic related to tests is implemented in `spec/test_config.rb`. The module is responsible for parsing the configuration file and passing the name of the adapter under test via an environment variable.

The task of setting up the database is implemented in `Rakefile` (the `db:postgresql:create` and `db:mysql:create` tasks). I considered performing this setup in `before(:suite)` but there are two drawbacks:

1. It wouldn't be possible to set up the database in some other way. `db:postgresql:create` and `db:mysql:create` are just convenience tasks whose use isn't required. If some custom setup is required it can be performed by hand. That wouldn't be possible, or it'd be more complicated, if `before(:suite)` set up the database.
2. The set up code is database-specific which would cause some conditionals to creep into the `before(:suite)` which would make the code more complicated without any real benefit.

If it turns out that there's a need to configure the adapters on a per-developer basis (e.g. someone doesn't want to locally access MySQL as `root`) then we can add `spec/config.yml` that would override settings from `spec/config.default.yml`. `spec/config.yml` would be ignored by git. I don't know whether this is an issue at the moment so I followed YAGNI.

# Commit Message
This commit automates testing against different database adapters. Currently `postgresql`, `mysql` and `sqlite3` are supported. The adapters are configured in `spec/config.default.yml`. The rake tasks for testing against each of the adapters are `spec:postgresql`, `spec:mysql` and `spec:sqlite3`. Additionally the `spec` task runs all these tasks in a sequence.

PostgreSQL and MySQL should be configured for testing by running the
`db:postgresql:create` and `db:mysql:create` tasks.

This code is loosely based on the Active Record test suite.