### PR TITLE
Reset column information

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,11 +28,11 @@ namespace :db do
 
   namespace :mysql do
     task :create do
-      %x(mysql --user=#{TestConfig['mysql']['username']} --password=#{TestConfig['mysql']['password']} --host=#{TestConfig['mysql']['host']} --execute="CREATE DATABASE #{TestConfig['mysql']['database']} DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci")
+      %x(mysql --user=#{TestConfig['mysql']['username']} --execute="CREATE DATABASE #{TestConfig['mysql']['database']} DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci")
     end
 
     task :drop do
-      %x(mysql --user=#{TestConfig['mysql']['username']} --password=#{TestConfig['mysql']['password']} --host=#{TestConfig['mysql']['host']} --execute="DROP DATABASE #{TestConfig['mysql']['database']}")
+      %x(mysql --user=#{TestConfig['mysql']['username']} --execute="DROP DATABASE #{TestConfig['mysql']['database']}")
     end
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -28,11 +28,11 @@ namespace :db do
 
   namespace :mysql do
     task :create do
-      %x(mysql --user=#{TestConfig['mysql']['username']} --execute="CREATE DATABASE #{TestConfig['mysql']['database']} DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci")
+      %x(mysql --user=#{TestConfig['mysql']['username']} --password=#{TestConfig['mysql']['password']} --host=#{TestConfig['mysql']['host']} --execute="CREATE DATABASE #{TestConfig['mysql']['database']} DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci")
     end
 
     task :drop do
-      %x(mysql --user=#{TestConfig['mysql']['username']} --execute="DROP DATABASE #{TestConfig['mysql']['database']}")
+      %x(mysql --user=#{TestConfig['mysql']['username']} --password=#{TestConfig['mysql']['password']} --host=#{TestConfig['mysql']['host']} --execute="DROP DATABASE #{TestConfig['mysql']['database']}")
     end
   end
 end

--- a/lib/temping.rb
+++ b/lib/temping.rb
@@ -25,6 +25,7 @@ class Temping
     def initialize(model_name, &block)
       @model_name = model_name
       klass.class_eval(&block) if block_given?
+      klass.reset_column_information
     end
 
     def klass

--- a/spec/temping_spec.rb
+++ b/spec/temping_spec.rb
@@ -49,6 +49,25 @@ describe Temping do
 
         Comment.columns.map(&:name).should include("count", "headline", "body")
       end
+
+      it "resets column information" do
+        Temping.create :human do
+          with_columns do |table|
+            table.integer :head_count
+          end
+        end
+
+        Human.columns.map(&:name).should include("head_count")
+
+        Temping.create :human do
+          with_columns do |table|
+            table.string :name
+            table.text :body
+          end
+        end
+
+        Human.columns.map(&:name).should include("name", "body")
+      end
     end
 
     describe ".teardown" do


### PR DESCRIPTION
Hey, this patches an issue when you create multiple models with Temping with the same name. AR will load the column information once, but not after. Calling reset_column_information after the schema update fixes it. Let me know if there's anything I should change!

I started a new PR to re-run the Travis build, for some reason it failed and I couldn't replicate it locally.