### PR TITLE
Update Ruby versions running on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 rvm:
+  - 2.3
   - 2.2
   - 2.1
-  - 2.0
-  - 1.9
+
 before_script:
   - bundle exec rake db:mysql:create
   - bundle exec rake db:postgresql:create


### PR DESCRIPTION
- Removed Ruby v 1.9, 2.0
- Added Ruby 2.3 to .travis.yml

Fixes https://github.com/jpignata/temping/issues/32