### PR TITLE
Add abiltity to override create_table options

### DIFF
--- a/lib/temping.rb
+++ b/lib/temping.rb
@@ -4,8 +4,8 @@ require "active_support/core_ext/string"
 class Temping
   @model_klasses = []
 
-  def self.create(model_name, &block)
-    factory = ModelFactory.new(model_name.to_s.classify, &block)
+  def self.create(model_name, options = {}, &block)
+    factory = ModelFactory.new(model_name.to_s.classify, options, &block)
     klass = factory.klass
     @model_klasses << klass
     klass
@@ -22,8 +22,9 @@ class Temping
   end
 
   class ModelFactory
-    def initialize(model_name, &block)
+    def initialize(model_name, options = {}, &block)
       @model_name = model_name
+      @options = options
       klass.class_eval(&block) if block_given?
     end
 
@@ -40,13 +41,14 @@ class Temping
         Object.const_set(@model_name, klass)
 
         klass.primary_key = :id
-        create_table
+        create_table(@options)
         add_methods
       end
     end
 
-    def create_table
-      connection.create_table(table_name, :temporary => true)
+    DEFAULT_OPTIONS = { :temporary => true }
+    def create_table(options = {})
+      connection.create_table(table_name, DEFAULT_OPTIONS.merge(options))
     end
 
     def add_methods

--- a/spec/temping_spec.rb
+++ b/spec/temping_spec.rb
@@ -7,6 +7,13 @@ describe Temping do
       post_class.ancestors.should include(ActiveRecord::Base)
       post_class.should == Post
       post_class.table_name.should == "posts"
+      post_class.connection.primary_key(:posts).should == "id"
+    end
+
+    it "creates table with given options" do
+      mushroom_class = Temping.create(:mushroom, primary_key: :guid)
+      mushroom_class.table_name.should == "mushrooms"
+      mushroom_class.connection.primary_key(:mushrooms).should == "guid"
     end
 
     it "evaluates block in the model's context" do


### PR DESCRIPTION
I need an ability to generate temporary PostgreSQL table with UUID primary keys. So I have to pass additional options to `create_table` method. 
