### PR TITLE
Implement Temping.cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ Rspec.configure do |config|
 end
 ```
 
+Alternatively you may want to just cleanup tables, but keep defined models:
+
+```ruby
+Temping.cleanup
+```
+
 ## Bugs, Features, Feedback
 
 All contributions are welcome! Please take a look at `CONTRIBUTING.md` for some

--- a/lib/temping.rb
+++ b/lib/temping.rb
@@ -4,21 +4,27 @@ require "active_support/core_ext/string"
 class Temping
   @model_klasses = []
 
-  def self.create(model_name, options = {}, &block)
-    factory = ModelFactory.new(model_name.to_s.classify, options, &block)
-    klass = factory.klass
-    @model_klasses << klass
-    klass
-  end
-
-  def self.teardown
-    @model_klasses.each do |klass|
-      if Object.const_defined?(klass.name)
-        klass.connection.drop_table(klass.table_name)
-        Object.send(:remove_const, klass.name)
-      end
+  class << self
+    def create(model_name, options = {}, &block)
+      factory = ModelFactory.new(model_name.to_s.classify, options, &block)
+      klass = factory.klass
+      @model_klasses << klass
+      klass
     end
-    @model_klasses.clear
+
+    def teardown
+      @model_klasses.each do |klass|
+        if Object.const_defined?(klass.name)
+          klass.connection.drop_table(klass.table_name)
+          Object.send(:remove_const, klass.name)
+        end
+      end
+      @model_klasses.clear
+    end
+
+    def cleanup
+      @model_klasses.each(&:destroy_all)
+    end
   end
 
   class ModelFactory

--- a/spec/temping_spec.rb
+++ b/spec/temping_spec.rb
@@ -96,5 +96,24 @@ describe Temping do
       end
     end
 
+    describe ".cleanup" do
+      before :all do
+        Temping.create(:user)
+      end
+
+      it "destroys all models" do
+        expect do
+          Temping.cleanup
+        end.not_to change { defined?(User) }
+      end
+
+      it "keeps constans and tables" do
+        User.create!
+
+        expect do
+          Temping.cleanup
+        end.to change { User.count }.from(1).to(0)
+      end
+    end
   end
 end


### PR DESCRIPTION
Hello 

I implemented `Temping.cleanup` method. It is very helpful when you want to test statically defined models.

```ruby
RSpec.describe SomeModelConcern do 
  Temping.create User

  after do 
    Temping.cleanup
  end 

  include_examples "concern behaviour", User
end 
```