### PR TITLE
Adds support for Rails 5 ApplicationRecord

### DIFF
--- a/lib/temping.rb
+++ b/lib/temping.rb
@@ -44,12 +44,20 @@ class Temping
     private
 
     def build
-      Class.new(ActiveRecord::Base).tap do |klass|
+      Class.new(model_parent_class).tap do |klass|
         Object.const_set(@model_name, klass)
 
         klass.primary_key = :id
         create_table(@options)
         add_methods
+      end
+    end
+
+    def model_parent_class
+      if ActiveRecord::VERSION::MAJOR > 4
+        ApplicationRecord
+      else
+        ActiveRecord::Base
       end
     end
 

--- a/lib/temping.rb
+++ b/lib/temping.rb
@@ -54,7 +54,7 @@ class Temping
     end
 
     def model_parent_class
-      if ActiveRecord::VERSION::MAJOR > 4
+      if ActiveRecord::VERSION::MAJOR > 4 && defined?(ApplicationRecord)
         ApplicationRecord
       else
         ActiveRecord::Base

--- a/spec/temping_spec.rb
+++ b/spec/temping_spec.rb
@@ -1,12 +1,6 @@
 require File.join(File.dirname(__FILE__), "/spec_helper")
 
 describe Temping do
-  before do
-    unless defined?(ApplicationRecord)
-      class ApplicationRecord < ActiveRecord::Base; end
-    end
-  end
-
   describe ".create" do
     it "creates and returns an ActiveRecord model" do
       post_class = Temping.create(:post)
@@ -27,9 +21,30 @@ describe Temping do
     context "when the ActiveRecord major version is greater than 4" do
       before { stub_const("ActiveRecord::VERSION::MAJOR", 5) }
 
-      it "creates a model that inherits from ApplicationRecord" do
-        kitty_class = Temping.create(:kittens)
-        expect(kitty_class.superclass).to eq(ApplicationRecord)
+      context "when ApplicationRecord is defined" do
+        before do
+          unless defined?(ApplicationRecord)
+            class ApplicationRecord < ActiveRecord::Base; end
+          end
+        end
+
+        it "creates a model that inherits from ApplicationRecord" do
+          kitty_class = Temping.create(:kittens)
+          expect(kitty_class.superclass).to eq(ApplicationRecord)
+        end
+      end
+
+      context "when ApplicationRecord is not defined" do
+        before do
+          if defined?(ApplicationRecord)
+            Object.send(:remove_const, :ApplicationRecord)
+          end
+        end
+
+        it "creates a model that inherits from ActiveRecord::Base" do
+          gerbil_class = Temping.create(:gerbil)
+          expect(gerbil_class.superclass).to eq(ActiveRecord::Base)
+        end
       end
     end
 

--- a/spec/temping_spec.rb
+++ b/spec/temping_spec.rb
@@ -1,13 +1,36 @@
 require File.join(File.dirname(__FILE__), "/spec_helper")
 
 describe Temping do
+  before do
+    unless defined?(ApplicationRecord)
+      class ApplicationRecord < ActiveRecord::Base; end
+    end
+  end
+
   describe ".create" do
     it "creates and returns an ActiveRecord model" do
       post_class = Temping.create(:post)
-      expect(post_class.ancestors).to include(ActiveRecord::Base)
       expect(post_class).to eq Post
       expect(post_class.table_name).to eq "posts"
       expect(post_class.connection.primary_key(:posts)).to eq "id"
+    end
+
+    context "when the ActiveRecord major version is less than 5" do
+      before { stub_const("ActiveRecord::VERSION::MAJOR", 4) }
+
+      it "creates a model that inherits from ActiveRecord::Base" do
+        puppy_class = Temping.create(:puppy)
+        expect(puppy_class.superclass).to eq(ActiveRecord::Base)
+      end
+    end
+
+    context "when the ActiveRecord major version is greater than 4" do
+      before { stub_const("ActiveRecord::VERSION::MAJOR", 5) }
+
+      it "creates a model that inherits from ApplicationRecord" do
+        kitty_class = Temping.create(:kittens)
+        expect(kitty_class.superclass).to eq(ApplicationRecord)
+      end
     end
 
     it "creates table with given options" do


### PR DESCRIPTION
* Rails 5 models now inherit from the ApplicationRecord abstract class, so
  Temping will set the generated model's superclass accordingly if the
  ActiveRecord major version is greater than 4