### PR TITLE
Add option to clear dependencies in `teardown` method.

### DIFF
--- a/lib/temping.rb
+++ b/lib/temping.rb
@@ -12,7 +12,7 @@ class Temping
       klass
     end
 
-    def teardown
+    def teardown(clear_dependencies: false)
       if @model_klasses.any?
         @model_klasses.each do |klass|
           if Object.const_defined?(klass.name)
@@ -21,7 +21,7 @@ class Temping
           end
         end
         @model_klasses.clear
-        ActiveSupport::Dependencies.clear
+        ActiveSupport::Dependencies.clear if clear_dependencies
       end
     end
 

--- a/spec/temping_spec.rb
+++ b/spec/temping_spec.rb
@@ -146,7 +146,7 @@ describe Temping do
 
         User.joins(:posts).to_a
 
-        Temping.teardown
+        Temping.teardown(clear_dependencies: true)
 
         Temping.create :user do
           has_many :posts


### PR DESCRIPTION
From errors reported in https://github.com/jpignata/temping/issues/45
this adds the `clear_dependencies` option to the `teardown` method,
making it optional to clear dependencies.