### PR TITLE
Allow a non-AR specific custom parent class

### DIFF
--- a/lib/temping.rb
+++ b/lib/temping.rb
@@ -47,7 +47,7 @@ class Temping
     private
 
     def build
-      Class.new(model_parent_class).tap do |klass|
+      Class.new(@options.fetch(:model_parent_class, model_parent_class)).tap do |klass|
         Object.const_set(@model_name, klass)
 
         klass.primary_key = @options[:primary_key] || :id


### PR DESCRIPTION
Currently, we have some custom superclasses for some of our domain. I wanted to see what you think of this change. I can add tests if you like it and want to incorporate it.
