### PR TITLE
Add option for specifying parent class

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,38 @@ Dog.create
 # => #<Dog id: d937951b-765c-4bc9-804e-3171d22117b0>
 ```
 
+## Options
+
+An option to specify the parent class can be given as a second parameter to `Temping.create`. This allows testing in environments where models inherit from a common base class.
+
+```ruby
+# A custom base model class
+class Vehicle < ActiveRecord::Base
+  self.abstract_class = true
+  def navigate_to(destination)
+    # non-vehicle specific logic
+  end
+end
+
+Temping.create :car, parent_class: Vehicle do
+  with_columns do |t|
+    t.string :name
+    t.integer :num_wheels
+  end
+end
+Temping.create :bus, parent_class: Vehicle do
+  with_columns do |t|
+    t.string :name
+    t.integer :num_wheels
+  end
+end
+
+my_car = Car.create
+my_car.navigate_to(:home)
+```
+
+
+
 ## Installation
 
 In your Gemfile:

--- a/lib/temping.rb
+++ b/lib/temping.rb
@@ -47,7 +47,7 @@ class Temping
     private
 
     def build
-      Class.new(model_parent_class).tap do |klass|
+      Class.new(@options.fetch(:parent_class, default_parent_class)).tap do |klass|
         Object.const_set(@model_name, klass)
 
         klass.primary_key = @options[:primary_key] || :id
@@ -56,7 +56,7 @@ class Temping
       end
     end
 
-    def model_parent_class
+    def default_parent_class
       if ActiveRecord::VERSION::MAJOR > 4 && defined?(ApplicationRecord)
         ApplicationRecord
       else

--- a/spec/temping_spec.rb
+++ b/spec/temping_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require File.join(File.dirname(__FILE__), "/spec_helper")
 
 describe Temping do
@@ -45,6 +46,28 @@ describe Temping do
           gerbil_class = Temping.create(:gerbil)
           expect(gerbil_class.superclass).to eq(ActiveRecord::Base)
         end
+      end
+    end
+
+    context "with a custom parent class" do
+      before do
+        unless defined?(TestBaseClass)
+          class TestBaseClass < ActiveRecord::Base
+            self.abstract_class = true
+          end
+        end
+      end
+      after do
+        Object.send(:remove_const, :TestBaseClass)
+      end
+      it 'uses the provided parent class option' do
+        child_class = Temping.create(:test_child, parent_class: TestBaseClass)
+        expect(child_class.superclass).to eq(TestBaseClass)
+        expect(child_class.new).to be_an(TestBaseClass)
+      end
+      it 'doesn’t affect other types' do
+          gerbil_class = Temping.create(:gerbil)
+          expect(gerbil_class.superclass).to eq(ActiveRecord::Base)
       end
     end
 


### PR DESCRIPTION
Like #48 I also had a need for this, so I whipped up an implementation that's almost exactly the same except it names the option `parent_class`. I debated using just `parent` but felt that might not be specific enough.

Per the discussion on #48, I added README and specs.

Thanks to @jetaggart  for making this easy 😁 