### PR TITLE
Setting license in gem package spec.

### DIFF
--- a/temping.gemspec
+++ b/temping.gemspec
@@ -5,6 +5,7 @@ Gem::Specification.new do |s|
   s.email       = "john@pignata.com"
   s.homepage    = "http://github.com/jpignata/temping"
   s.summary     = "Create temporary table-backed ActiveRecord models for use in tests"
+  s.license     = "MIT"
 
   s.files = ["lib/temping.rb"]
 


### PR DESCRIPTION
To allow automated tools (such as LicenseFinder [https://github.com/pivotal/LicenseFinder]) to detect and
report licenses in use by a system and its dependencies.

Further details here: https://github.com/pivotal/LicenseFinder#a-plea-to-package-authors-and-maintainers