### PR TITLE
Correctly drop related tables

### DIFF
--- a/lib/temping.rb
+++ b/lib/temping.rb
@@ -14,7 +14,7 @@ class Temping
 
     def teardown
       if @model_klasses.any?
-        @model_klasses.each do |klass|
+        @model_klasses.reverse.each do |klass|
           if Object.const_defined?(klass.name)
             klass.connection.drop_table(klass.table_name)
             Object.send(:remove_const, klass.name)

--- a/spec/temping_spec.rb
+++ b/spec/temping_spec.rb
@@ -192,6 +192,21 @@ describe Temping do
 
         expect { User.joins(:comments).to_a }.not_to raise_error
       end
+
+      context "when foreign key constraints exist" do
+        before do
+          Temping.create(:containers)
+          Temping.create(:items) do
+            with_columns do |t|
+              t.references :container, foreign_key: true
+            end
+          end
+        end
+
+        it "undefines the models" do
+          expect { Temping.teardown }.not_to raise_error
+        end
+      end
     end
 
     describe ".cleanup" do


### PR DESCRIPTION
This commit fixes a problem that prevented Temping from correctly
tearing down a set of related tables. A foreign constraint would cause
an error during teardown because the tables were dropped in the wrong
order.