### PR TITLE
Use explicit kwargs double splat for Ruby 3+

### DIFF
--- a/lib/temping.rb
+++ b/lib/temping.rb
@@ -66,7 +66,7 @@ class Temping
 
     DEFAULT_OPTIONS = { :temporary => true }
     def create_table(options = {})
-      connection.create_table(table_name, DEFAULT_OPTIONS.merge(options))
+      connection.create_table(table_name, **DEFAULT_OPTIONS.merge(options))
     end
 
     def add_methods


### PR DESCRIPTION
This line of code produced a deprecation warning in Ruby 2.7 and now fails in Ruby 3.0.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
