### PR TITLE
Fix kwargs issue

### DIFF
--- a/lib/temping.rb
+++ b/lib/temping.rb
@@ -66,7 +66,7 @@ class Temping
 
     DEFAULT_OPTIONS = { :temporary => true }
     def create_table(options = {})
-      connection.create_table(table_name, DEFAULT_OPTIONS.merge(options))
+      connection.create_table(table_name, **DEFAULT_OPTIONS.merge(options))
     end
 
     def add_methods


### PR DESCRIPTION
Hi, I'm in process to upgrade an app to Ruby 3.0 and found this issue. Ruby 3.0 drops ambiguity between keyword arguments and hash parameters, calls should be explicit to work properly.
