### PR TITLE
Fix ruby versions in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,31 +9,31 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - ruby: 3.1
+          - ruby: '3.1'
             gemfile: gemfiles/activerecord_7.0.gemfile
-          - ruby: 3.1
+          - ruby: '3.1'
             gemfile: gemfiles/activerecord_6.1.gemfile
-          - ruby: 3.0
+          - ruby: '3.0'
             gemfile: gemfiles/activerecord_7.0.gemfile
-          - ruby: 3.0
+          - ruby: '3.0'
             gemfile: gemfiles/activerecord_6.1.gemfile
-          - ruby: 2.7
+          - ruby: '2.7'
             gemfile: gemfiles/activerecord_7.0.gemfile
-          - ruby: 2.7
+          - ruby: '2.7'
             gemfile: gemfiles/activerecord_6.1.gemfile
-          - ruby: 2.7
+          - ruby: '2.7'
             gemfile: gemfiles/activerecord_6.0.gemfile
-          - ruby: 2.6
+          - ruby: '2.6'
             gemfile: gemfiles/activerecord_6.1.gemfile
-          - ruby: 2.6
+          - ruby: '2.6'
             gemfile: gemfiles/activerecord_6.0.gemfile
-          - ruby: 2.5
+          - ruby: '2.5'
             gemfile: gemfiles/activerecord_6.1.gemfile
-          - ruby: 2.5
+          - ruby: '2.5'
             gemfile: gemfiles/activerecord_6.0.gemfile
-          - ruby: jruby
+          - ruby: 'jruby'
             gemfile: gemfiles/activerecord_6.1.gemfile
-          - ruby: jruby
+          - ruby: 'jruby'
             gemfile: gemfiles/activerecord_6.0.gemfile
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}


### PR DESCRIPTION
YAML in .github/workflows/tests.yaml of ruby versions is parsed as integers which leads to problems for ruby `3.0`, it is parsed as `3` which in turn translates to `3.1`.
Fixing this.