### PR TITLE
Fix Rails 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ User-visible changes worth mentioning.
 
 ## Unreleased
 - Add support for Ruby 3.0 and above
+- Add support for Rails 7.0
 - Drop support for Ruby below 2.5
 - Drop support for Rails below 6.0
 

--- a/lib/temping.rb
+++ b/lib/temping.rb
@@ -21,7 +21,7 @@ class Temping
           end
         end
         @model_klasses.clear
-        ActiveSupport::Dependencies::Reference.clear!
+        ActiveSupport::Dependencies::Reference.clear! if ActiveRecord::VERSION::MAJOR < 7
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,7 +40,9 @@ RSpec.configure do |config|
   end
 end
 
-ActiveSupport::Dependencies.autoload_paths << File.join(__dir__, 'autoload')
+if ActiveRecord::VERSION::MAJOR < 7
+  ActiveSupport::Dependencies.autoload_paths << File.join(__dir__, 'autoload')
+end
 
 # The #temporary_table_exists? is required by the spec. The implementation
 # provided by Rails doesn't work for temporary tables in SQLite as they are not

--- a/spec/temping_spec.rb
+++ b/spec/temping_spec.rb
@@ -169,8 +169,12 @@ describe Temping do
 
         User.joins(:posts).to_a
 
-        AUTOLOADABLE_CONSTANT
-        expect { Temping.teardown }.not_to change { defined?(AUTOLOADABLE_CONSTANT) }
+        if ActiveRecord::VERSION::MAJOR < 7
+          AUTOLOADABLE_CONSTANT
+          expect { Temping.teardown }.not_to change { defined?(AUTOLOADABLE_CONSTANT) }
+        else
+          Temping.teardown
+        end
 
         Temping.create :user do
           has_many :posts


### PR DESCRIPTION
Fixes #67 

Previously there was added some code in https://github.com/jpignata/temping/pull/40 to handle cases when models created by Temping are cached in ActiveRecord (ActiveSupport?) reflection store.
However in Rails 7 autoloading was hugely reworked, most of the code from ActiveSupport::Dependencies was deleted as described in https://rubyonrails.org/2021/9/3/autoloading-in-rails-7-get-ready, so this whole problem seems to be gone. At the very least I can't reproduce the exception from the test case added in https://github.com/jpignata/temping/pull/40 with ActiveRecord 7 (if I just remove `ActiveSupport::Dependencies::Reference.clear!`). 

So, let's just try removing that line for Rails >= 7.