### PR TITLE
Integrate standardrb into CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,35 @@ on:
       - README.md
 
 jobs:
+  linter:
+    name: Run StandardRB linter
+    runs-on: ubuntu-latest
+    env:
+      BUNDLE_GEMFILE: gemfiles/activerecord_7.0.gemfile
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+      - name: Run StandardRB
+        id: offenses
+        run: |
+          echo "LINTER_OFFENSES<<EOF" >> $GITHUB_OUTPUT
+          echo "$(${{ matrix.env }} bundle exec standardrb)" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+      - name: Print offenses
+        if: steps.offenses.outputs.LINTER_OFFENSES
+        run: |
+          echo '${{ steps.offenses.outputs.LINTER_OFFENSES }}'
+      - name: Fail if StandardRB offenses found
+        if: steps.offenses.outputs.LINTER_OFFENSES
+        uses: actions/github-script@v6
+        with:
+          script: "core.setFailed('StandardRB linter offenses found. Please inspect the details \
+                                   of the previous step in the job for more info.')"
   tests:
     name: Run tests (ruby ${{ matrix.ruby }}, rails ${{ matrix.rails }})
     runs-on: ubuntu-latest
@@ -71,7 +100,7 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - name: Run tests
-        run: ${{ matrix.env }} bundle exec rake
+        run: ${{ matrix.env }} bundle exec rake spec
       - name: Upload code coverage results as artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ to start the container. Once the container is up and running you can run
 $ rake
 ``` 
 
-to run the whole test suite. 
+to run the whole test suite including StandardRB linter. 
 
 If you want to test a particular database adapter version run
 `rake spec:<adapter version>`, e.g. `rake spec:mysql8.0` 

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,8 @@
-require 'rspec/core/rake_task'
-require_relative 'spec/test_config'
+require "rspec/core/rake_task"
+require "standard/rake"
+require_relative "spec/test_config"
 
-task default: [:spec]
+task default: [:standard, :spec]
 
 task spec: TestConfig.adapter_versions.map { |adapter_version| "spec:#{adapter_version}" }
 
@@ -9,7 +10,7 @@ TestConfig.adapter_versions.each do |adapter_version|
   namespace :spec do
     RSpec::Core::RakeTask.new(adapter_version) do |spec|
       TestConfig.current_adapter_version = adapter_version
-      spec.rspec_opts = '--colour'
+      spec.rspec_opts = "--colour"
     end
   end
 end

--- a/lib/temping.rb
+++ b/lib/temping.rb
@@ -34,7 +34,7 @@ class Temping
     def initialize(model_name, options = {}, &block)
       @model_name = model_name
       @options = options
-      klass.class_eval(&block) if block_given?
+      klass.class_eval(&block) if block
       klass.reset_column_information
     end
 
@@ -64,7 +64,7 @@ class Temping
       end
     end
 
-    DEFAULT_OPTIONS = { :temporary => true }
+    DEFAULT_OPTIONS = {temporary: true}
     def create_table(options = {})
       connection.create_table(table_name, **DEFAULT_OPTIONS.merge(options))
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,16 +15,16 @@ RSpec.configure do |config|
     config = TestConfig.current_config
     puts "Testing adapter version #{TestConfig.current_adapter_version} " \
          "(#{RUBY_DESCRIPTION}, ActiveRecord #{ActiveRecord::VERSION::STRING}, " \
-         "gemfile #{ENV['BUNDLE_GEMFILE']})"
-    case config['adapter']
-    when 'mysql2'
-      ActiveRecord::Base.establish_connection(config.except('database'))
-      ActiveRecord::Base.connection.execute("CREATE DATABASE #{config['database']} " \
+         "gemfile #{ENV["BUNDLE_GEMFILE"]})"
+    case config["adapter"]
+    when "mysql2"
+      ActiveRecord::Base.establish_connection(config.except("database"))
+      ActiveRecord::Base.connection.execute("CREATE DATABASE #{config["database"]} " \
                                             "DEFAULT CHARACTER SET utf8 " \
                                             "DEFAULT COLLATE utf8_unicode_ci")
-    when 'postgresql'
-      ActiveRecord::Base.establish_connection(config.except('database'))
-      ActiveRecord::Base.connection.execute("CREATE DATABASE #{config['database']} " \
+    when "postgresql"
+      ActiveRecord::Base.establish_connection(config.except("database"))
+      ActiveRecord::Base.connection.execute("CREATE DATABASE #{config["database"]} " \
                                             "ENCODING = 'UTF8'" \
                                             "TEMPLATE 'template0'")
     end
@@ -33,20 +33,20 @@ RSpec.configure do |config|
 
   config.after(:suite) do
     config = TestConfig.current_config
-    case config['adapter']
-    when 'mysql2'
-      ActiveRecord::Base.connection.execute("DROP DATABASE IF EXISTS #{config['database']}")
-    when 'postgresql'
+    case config["adapter"]
+    when "mysql2"
+      ActiveRecord::Base.connection.execute("DROP DATABASE IF EXISTS #{config["database"]}")
+    when "postgresql"
       ActiveRecord::Base.remove_connection
-      ActiveRecord::Base.establish_connection(config.except('database').merge('database': 'template1'))
-      ActiveRecord::Base.connection.execute("DROP DATABASE IF EXISTS #{config['database']}")
+      ActiveRecord::Base.establish_connection(config.except("database").merge(database: "template1"))
+      ActiveRecord::Base.connection.execute("DROP DATABASE IF EXISTS #{config["database"]}")
     end
     ActiveRecord::Base.remove_connection
   end
 end
 
 if ActiveRecord::VERSION::MAJOR < 7
-  ActiveSupport::Dependencies.autoload_paths << File.join(__dir__, 'autoload')
+  ActiveSupport::Dependencies.autoload_paths << File.join(__dir__, "autoload")
 end
 
 # The #temporary_table_exists? is required by the spec. The implementation
@@ -72,7 +72,7 @@ module ActiveRecord::ConnectionAdapters
   end
 
   class SQLite3Adapter < AbstractAdapter
-    def temporary_tables(name = nil, table_name = nil) #:nodoc:
+    def temporary_tables(name = nil, table_name = nil) # :nodoc:
       sql = <<-SQL
               SELECT name
               FROM sqlite_temp_master
@@ -80,8 +80,8 @@ module ActiveRecord::ConnectionAdapters
       SQL
       sql << " AND name = #{quote_table_name(table_name)}" if table_name
 
-      exec_query(sql, 'SCHEMA').map do |row|
-        row['name']
+      exec_query(sql, "SCHEMA").map do |row|
+        row["name"]
       end
     end
 

--- a/spec/temping_spec.rb
+++ b/spec/temping_spec.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 require File.join(File.dirname(__FILE__), "/spec_helper")
 
 describe Temping do
@@ -49,13 +48,13 @@ describe Temping do
         Object.send(:remove_const, :TestBaseClass)
       end
 
-      it 'uses the provided parent class option' do
+      it "uses the provided parent class option" do
         child_class = Temping.create(:test_child, parent_class: TestBaseClass)
         expect(child_class.superclass).to eq(TestBaseClass)
         expect(child_class.new).to be_an(TestBaseClass)
       end
 
-      it 'doesn’t affect other types' do
+      it "doesn’t affect other types" do
         gerbil_class = Temping.create(:gerbil)
         expect(gerbil_class.superclass).to eq(ActiveRecord::Base)
       end
@@ -146,7 +145,7 @@ describe Temping do
         expect(Object.const_defined?(:User)).to be_falsey
       end
 
-      it 'clears the reflections cache' do
+      it "clears the reflections cache" do
         Temping.create :user do
           has_many :posts
         end
@@ -160,7 +159,7 @@ describe Temping do
         User.joins(:posts).to_a
 
         if ActiveRecord::VERSION::MAJOR < 7
-          AUTOLOADABLE_CONSTANT
+          expect { AUTOLOADABLE_CONSTANT }.not_to raise_error
           expect { Temping.teardown }.not_to change { defined?(AUTOLOADABLE_CONSTANT) }
         else
           Temping.teardown

--- a/spec/test_config.rb
+++ b/spec/test_config.rb
@@ -1,4 +1,4 @@
-require 'yaml'
+require "yaml"
 
 module TestConfig
   class << self
@@ -16,11 +16,11 @@ module TestConfig
     # The adapter is chosen by the parent process but tested by the child process. Using an
     # environment variable is the simplest way of passing a value from the parent to the child.
     def current_adapter_version
-      ENV.fetch('TEMPING_ADAPTER_VERSION')
+      ENV.fetch("TEMPING_ADAPTER_VERSION")
     end
 
     def current_adapter_version=(adapter_version)
-      ENV['TEMPING_ADAPTER_VERSION'] = adapter_version
+      ENV["TEMPING_ADAPTER_VERSION"] = adapter_version
     end
 
     def config
@@ -29,7 +29,7 @@ module TestConfig
     private :config
 
     def config_path
-      File.join(File.dirname(__FILE__), 'config.default.yml')
+      File.join(File.dirname(__FILE__), "config.default.yml")
     end
     private :config_path
   end

--- a/temping.gemspec
+++ b/temping.gemspec
@@ -1,11 +1,11 @@
 Gem::Specification.new do |s|
-  s.name        = "temping"
-  s.version     = "3.10.0"
-  s.authors     = ["John Pignata"]
-  s.email       = "john@pignata.com"
-  s.homepage    = "http://github.com/jpignata/temping"
-  s.summary     = "Create temporary table-backed ActiveRecord models for use in tests"
-  s.license     = "MIT"
+  s.name = "temping"
+  s.version = "3.10.0"
+  s.authors = ["John Pignata"]
+  s.email = "john@pignata.com"
+  s.homepage = "http://github.com/jpignata/temping"
+  s.summary = "Create temporary table-backed ActiveRecord models for use in tests"
+  s.license = "MIT"
 
   s.files = ["lib/temping.rb"]
 
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "appraisal"
 
-  if RUBY_PLATFORM =~ /java/
+  if RUBY_PLATFORM.match?(/java/)
     s.add_development_dependency "activerecord-jdbcsqlite3-adapter", ">= 60.0"
     s.add_development_dependency "activerecord-jdbcpostgresql-adapter", ">= 60.0"
     s.add_development_dependency "activerecord-jdbcmysql-adapter", ">= 60.0"
@@ -28,4 +28,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", "~> 3.12"
   s.add_development_dependency "rake", "~> 13.0"
   s.add_development_dependency "simplecov", "~> 0.18"
+  s.add_development_dependency "standard"
 end


### PR DESCRIPTION
Integrate [standardrb](https://github.com/testdouble/standard) into CI.
Fail workflows if offenses found.
(This will be just indicative without any consequence since maintainers can merge any PR anyway even if the coverage is less than 100%).