### PR TITLE
Return activesupport back as explicit dependency

### DIFF
--- a/.standard.yml
+++ b/.standard.yml
@@ -1,0 +1,1 @@
+ruby_version: 2.0.0

--- a/Appraisals
+++ b/Appraisals
@@ -1,15 +1,20 @@
 appraise "activerecord-5.2" do
   gem "activerecord", "~> 5.2.8"
+  gem "activesupport", "~> 5.2.8"
 end
 
 appraise "activerecord-6.0" do
   gem "activerecord", "~> 6.0.6"
+  gem "activesupport", "~> 6.0.6"
 end
 
 appraise "activerecord-6.1" do
   gem "activerecord", "~> 6.1.7"
+  gem "activesupport", "~> 6.1.7"
 end
 
 appraise "activerecord-7.0" do
   gem "activerecord", "~> 7.0.4"
+  gem "activesupport", "~> 7.0.4"
+  gem "standard", "~> 1.16"
 end

--- a/gemfiles/activerecord_5.2.gemfile
+++ b/gemfiles/activerecord_5.2.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "activerecord", "~> 5.2.8"
+gem "activesupport", "~> 5.2.8"
 
 gemspec path: "../"

--- a/gemfiles/activerecord_6.0.gemfile
+++ b/gemfiles/activerecord_6.0.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "activerecord", "~> 6.0.6"
+gem "activesupport", "~> 6.0.6"
 
 gemspec path: "../"

--- a/gemfiles/activerecord_6.1.gemfile
+++ b/gemfiles/activerecord_6.1.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "activerecord", "~> 6.1.7"
+gem "activesupport", "~> 6.1.7"
 
 gemspec path: "../"

--- a/gemfiles/activerecord_7.0.gemfile
+++ b/gemfiles/activerecord_7.0.gemfile
@@ -3,5 +3,7 @@
 source "https://rubygems.org"
 
 gem "activerecord", "~> 7.0.4"
+gem "activesupport", "~> 7.0.4"
+gem "standard", "~> 1.16"
 
 gemspec path: "../"

--- a/temping.gemspec
+++ b/temping.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.0"
 
   s.add_dependency "activerecord", ">= 5.2", "< 7.1"
+  s.add_dependency "activesupport", ">= 5.2", "< 7.1"
 
   s.add_development_dependency "appraisal"
 


### PR DESCRIPTION
Changes:

* Return activesupport back as explicit dependency
* Specify 2.0.0 as a ruby version for StandardRB linter (as a minimum supported version)