### PR TITLE
Support namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ User-visible changes worth mentioning.
 ---
 
 ## Unreleased
+- Support [namespaces](README.md#namespaces)
 - Fix `.teardown` and `.cleanup` methods to process models in the reverse order 
 (last in, first out) - Thanks @gregnavis
 - Add support for Ruby 3.0 and above - Thanks @dark-panda

--- a/README.md
+++ b/README.md
@@ -12,132 +12,15 @@ relying on a concrete class.
 Temping will use your existing database connection. As we're using temporary
 tables all data will be dropped when the database connection is terminated.
 
-## Examples
+## Table of Contents
 
-The basic setup of a model involves calling _create_ with a symbol that
-represents the class name of the model you wish to create. By default,
-this will create a temporary table with an _id_ column.
-
-```ruby
-Temping.create :dog
-
-Dog.create => #<Dog id: 1>
-Dog.table_name => "dogs"
-Dog => Dog(id: integer)
-```
-
-Keep in mind, the table name will always be pluralized, while the class name will be singular.
-
-```ruby
-Temping.create :dogs
-
-Dog.table_name => "dogs"
-Dogs => NameError: uninitialized constant Dogs
-```
-
-Additional database columns can be specified via the _with_columns_ method
-which uses Rails migration syntax:
-
-```ruby
-Temping.create :dog do
-  with_columns do |t|
-    t.string :name
-    t.integer :age, :weight
-  end
-end
-
-Dog.create
-
-# => #<Dog id: 1, name: nil, age: nil, weight: nil>
-```
-
-When a block is passed to _create_, it is evaluated in the context of the class.
-This means anything you do in an ActiveRecord model class body can be
-accomplished in the block including method definitions, validations, module
-includes, etc.
-
-```ruby
-Temping.create :dog do
-  validates :name, presence: true
-
-  with_columns do |t|
-    t.string :name
-    t.integer :age, :weight
-  end
-
-  def quack
-    "arf!"
-  end
-end
-
-Dog.create!
-
-# => ActiveRecord::RecordInvalid: Validation failed: Name can't be blank
-
-codey = Dog.create! name: "Codey"
-codey.quack
-
-# => "arf!"
-```
-
-All attributes you can pass to `create_table` can be evaluated too. For example you can create a dog with a primary key of the type uuid:
-
-```ruby
-Temping.create :dog, id: :uuid, default: -> { 'uuid_generate_v4()' }
-
-Dog.create
-
-# => #<Dog id: d937951b-765c-4bc9-804e-3171d22117b0>
-```
-
-## Options
-
-An option to specify the parent class can be given as a second parameter to `Temping.create`. This allows testing in environments where models inherit from a common base class.
-
-```ruby
-# A custom base model class
-class Vehicle < ActiveRecord::Base
-  self.abstract_class = true
-  def navigate_to(destination)
-    # non-vehicle specific logic
-  end
-end
-
-Temping.create :car, parent_class: Vehicle do
-  with_columns do |t|
-    t.string :name
-    t.integer :num_wheels
-  end
-end
-Temping.create :bus, parent_class: Vehicle do
-  with_columns do |t|
-    t.string :name
-    t.integer :num_wheels
-  end
-end
-
-my_car = Car.create
-my_car.navigate_to(:home)
-```
-
-## Foreign Keys
-
-Temporary tables in [MySQL](https://dev.mysql.com/doc/refman/8.0/en/create-table-foreign-keys.html) 
-cannot have foreign keys. PostgreSQL supports them though.
-If you want to use foreign keys with Temping in MySQL you might want to consider 
-making tables permanent by overwriting `temporary` option when you set up a model:
-
-```ruby
-Temping.create :user, temporary: false
-Temping.create :post, temporary: false do
-  with_columns do |t|
-    t.references :user, foreign_key: true
-  end
-end
-```
-
-This however is not a recommended approach because the whole idea of Temping 
-is about using **temporary** tables.
+- [Installation](#installation)
+- [Examples](#examples)
+- [Parent Classes](#parent-classes)
+- [Namespaces](#namespaces)
+- [Foreign Keys](#foreign-keys)
+- [Tested Environments](#tested-environments)
+- [Contributing](#contributing)
 
 ## Installation
 
@@ -171,13 +54,192 @@ RSpec.configure do |config|
 end
 ```
 
-Alternatively you may want to just cleanup tables, but keep defined models:
+Alternatively you may want to just cleanup tables but keep defined models in memory:
 
 ```ruby
 Temping.cleanup
 ```
 
-## Support
+## Examples
+
+The basic setup of a model involves calling `create` with a symbol that
+represents the class name of the model you wish to create. By default,
+this will create a temporary table with an `id` column.
+
+```ruby
+Temping.create(:dog)
+
+Dog.create # => <Dog id: 1>
+Dog.table_name # => "dogs"
+Dog # => Dog(id: integer)
+```
+
+Keep in mind, the table name will always be pluralized, while the class name will be singular.
+
+```ruby
+Temping.create(:dogs)
+
+Dog.table_name # => "dogs"
+Dogs # => NameError: uninitialized constant Dogs
+```
+
+Additional database columns can be specified via the `with_columns` method
+which uses Rails migration syntax:
+
+```ruby
+Temping.create(:dog) do
+  with_columns do |t|
+    t.string :name
+    t.integer :age, :weight
+  end
+end
+
+Dog.create # => <Dog id: 1, name: nil, age: nil, weight: nil>
+```
+
+When a block is passed to `create`, it is evaluated in the context of the class.
+This means anything you do in an ActiveRecord model class body can be
+accomplished in the block including method definitions, validations, module
+includes, etc.
+
+```ruby
+Temping.create(:dog) do
+  validates :name, presence: true
+
+  with_columns do |t|
+    t.string :name
+    t.integer :age, :weight
+  end
+
+  def quack
+    "arf!"
+  end
+end
+
+Dog.create!
+
+# => ActiveRecord::RecordInvalid: Validation failed: Name can't be blank
+
+codey = Dog.create!(name: "Codey")
+codey.quack
+
+# => "arf!"
+```
+
+All attributes you can pass to `create_table` can be evaluated too. 
+For example you can create a dog with a primary key of the type uuid:
+
+```ruby
+Temping.create(:dog, id: :uuid, default: -> { "uuid_generate_v4()" })
+
+Dog.create # => <Dog id: d937951b-765c-4bc9-804e-3171d22117b0>
+```
+
+## Parent Classes
+
+An option to specify the parent class can be given as a second parameter to `Temping.create`. This allows testing in environments where models inherit from a common base class.
+
+```ruby
+# A custom base model class
+class Vehicle < ActiveRecord::Base
+  self.abstract_class = true
+  
+  def navigate_to(destination)
+    # non-vehicle specific logic
+  end
+end
+
+Temping.create(:car, parent_class: Vehicle) do
+  with_columns do |t|
+    t.string :name
+    t.integer :num_wheels
+  end
+end
+Temping.create(:bus, parent_class: Vehicle) do
+  with_columns do |t|
+    t.string :name
+    t.integer :num_wheels
+  end
+end
+
+my_car = Car.create
+my_car.navigate_to(:home)
+```
+
+## Namespaces
+
+Temping supports creating models within namespaces. 
+You can do this either by just including the full namespace in the name:
+
+```ruby
+Temping.create("animal/cat")
+
+Animal::Cat.create # => <Animal::Cat id: 1>
+Animal::Cat.table_name # => "cats"
+Animal::Cat # => Animal::Cat(id: integer)
+```
+
+Or you can create the module(s) yourself:
+
+```ruby
+module Engineers
+  def self.table_name_prefix
+    "hard_working_"
+  end
+end
+Temping.create("engineers/developers")
+
+Engineers::Developer.create # => <Engineers::Developer id: 1> 
+Engineers::Developer.table_name # => "hard_working_developers"
+Engineers::Developer # => Engineers::Developer(id: integer)
+```
+
+Please note that if you create the modules yourself, Temping will NOT attempt 
+to undefine them when you call `Temping.teardown`, it will only undefine the modules/models 
+created by itself:
+
+```ruby 
+module Engineers; end
+Temping.create("engineers/developers")
+Temping.create("animal/cat")
+
+Temping.teardown
+
+Object.const_defined?("Engineers") # => true
+Object.const_defined?("Engineers::Developer") # => false
+Object.const_defined?("Animal") # => false
+Object.const_defined?("Animal::Cat") # => false
+```
+
+Deep namespaces are supported as well:
+
+```ruby 
+Temping.create("continents/countries/cities/streets/buildings")
+
+# => Continents::Countries::Cities::Streets::Building(id: integer) 
+```
+
+## Foreign Keys
+
+Temporary tables in [MySQL](https://dev.mysql.com/doc/refman/8.0/en/create-table-foreign-keys.html) 
+cannot have foreign keys. PostgreSQL doesn't have this limitation.
+
+If you want to use foreign keys with Temping in MySQL you might want to consider 
+making tables permanent by overwriting `temporary` option when you set up a model:
+
+```ruby
+Temping.create(:user, temporary: false)
+Temping.create(:post, temporary: false) do
+  with_columns do |t|
+    t.references :user, foreign_key: true
+  end
+end
+```
+
+This however is not a recommended approach because the whole idea of Temping 
+is about using **temporary** tables.
+
+## Tested Environments
 
 The latest version of this gem is tested with the following interpreters/gems:
 
@@ -197,10 +259,11 @@ with the following database systems:
 * MySQL (versions 5.5-8.0)
 * PostgreSQL (versions 10-15)
 
-If you need to support older versions of ruby or ActiveRecord you might have to use
+If you need to support older versions of Ruby or ActiveRecord you might have to use
 the older versions of this gem (3.10.0 or below).
 
-## Bugs, Features, Feedback
+## Contributing
 
-All contributions are welcome! Please take a look at `CONTRIBUTING.md` for some
-tips.
+All contributions are welcome! 
+
+Please take a look at `CONTRIBUTING.md` for some tips.

--- a/lib/temping.rb
+++ b/lib/temping.rb
@@ -1,94 +1,149 @@
 require "active_record"
 require "active_support/core_ext/string"
 
+class Temping; end
+
+require "temping/namespace_factory"
+require "temping/model_factory"
+
 class Temping
-  @model_klasses = []
+  @namespaces = []
+  @models = []
 
   class << self
-    def create(model_name, options = {}, &block)
-      factory = ModelFactory.new(model_name.to_s.classify, options, &block)
-      klass = factory.klass
-      @model_klasses << klass
-      klass
+    # Create a new temporary ActiveRecord model with a name specified by `name`.
+    #
+    # Provided `options` are all passed to the inner `create_table` call so anything
+    # acceptable by `create_table` method can be passed here.
+    # In addition `options` can include `parent_class` key to specify parent class for the model.
+    # When `block` is passed, it is evaluated in the context of the class. This means anything you
+    # do in an ActiveRecord model class body can be accomplished in `block` including method
+    # definitions, validations, module includes, etc.
+    # Additional database columns can be specified via `with_columns` method inside `block`,
+    # which uses Rails migration syntax.
+    def create(name, options = {}, &block)
+      namespace_name, model_name = split_name(name)
+      namespace = namespace_name ? NamespaceFactory.new(namespace_name).klass : Object
+      @namespaces << namespace if namespace_name
+      model = ModelFactory.new(model_name, namespace, options, &block).klass
+      @models << model
+      model
     end
 
+    # Completely destroy everything created by Temping.
+    #
+    # This includes:
+    # * removing all the records in the models created by Temping and dropping their tables
+    # from the database;
+    # * undefining model constants so they cannot be pointed to anymore in the code.
     def teardown
-      if @model_klasses.any?
-        @model_klasses.reverse_each do |klass|
-          if Object.const_defined?(klass.name)
-            klass.connection.drop_table(klass.table_name)
-            Object.send(:remove_const, klass.name)
-          end
-        end
-        @model_klasses.clear
+      if @models.any?
+        teardown_models
+        teardown_namespaces
         ActiveSupport::Dependencies::Reference.clear! if ActiveRecord::VERSION::MAJOR < 7
       end
     end
 
+    # Destroy all records from each of the models created by Temping.
+    #
+    # This does not undefine the models themselves or drop their tables.
+    # This method is an alternative to `teardown` if you want to keep the models and tables.
     def cleanup
-      @model_klasses.reverse_each(&:destroy_all)
-    end
-  end
-
-  class ModelFactory
-    def initialize(model_name, options = {}, &block)
-      @model_name = model_name
-      @options = options
-      klass.class_eval(&block) if block
-      klass.reset_column_information
+      @models.reverse_each(&:destroy_all)
     end
 
-    def klass
-      @klass ||= Object.const_get(@model_name)
-    rescue NameError
-      @klass = build
+    # Split the provided name finding the namespace (if any) and the model name without namespace.
+    def split_name(name)
+      classified_name = name.to_s.classify
+      name_parts = classified_name.split("::")
+      namespace_name = name_parts[0...-1].join("::")
+      return [nil, classified_name] if namespace_name.empty?
+
+      [namespace_name, name_parts.last]
     end
+    private :split_name
 
-    private
-
-    def build
-      Class.new(@options.fetch(:parent_class, default_parent_class)).tap do |klass|
-        Object.const_set(@model_name, klass)
-
-        klass.primary_key = @options[:primary_key] || :id
-        create_table(@options)
-        add_methods
-      end
-    end
-
-    def default_parent_class
-      if defined?(ApplicationRecord)
-        ApplicationRecord
-      else
-        ActiveRecord::Base
-      end
-    end
-
-    DEFAULT_OPTIONS = {temporary: true}
-    def create_table(options = {})
-      connection.create_table(table_name, **DEFAULT_OPTIONS.merge(options))
-    end
-
-    def add_methods
-      class << klass
-        def with_columns
-          connection.change_table(table_name) do |table|
-            yield(table)
-          end
-        end
-
-        def table_exists?
-          true
+    # Iterate over `@models`, undefine model constants, drop tables, and remove the constants
+    # from the array one by one starting with the models defined last. (Models defined later
+    # can point to older models by using foreign keys so they have to be removed first).
+    def teardown_models
+      @models.reverse_each do |model|
+        model_name_without_namespace = model.name.split("::").last
+        if model.namespace.const_defined?(model_name_without_namespace)
+          model.connection.drop_table(model.table_name)
+          model.namespace.send(:remove_const, model_name_without_namespace)
         end
       end
+      @models.clear
     end
+    private :teardown_models
 
-    def connection
-      klass.connection
+    # Iterate over `@namespaces`, undefine modules and remove them from the array one by one
+    # starting with the deepest ones first.
+    def teardown_namespaces
+      @namespaces.select! { |namespace| namespace_still_defined?(namespace) }
+      until @namespaces.empty?
+        namespace, index = @namespaces.each_with_index.max_by { |n, _i| n.name.split("::").length }
+        parts = namespace.name.split("::")
+        parent = parts.length == 1 ? Object : parts[0...-1].join("::").constantize
+        parent.send(:remove_const, parts.last) if namespace_removable?(namespace, parts, parent)
+        delete_or_trim_in_namespaces(parent, parts, index)
+      end
     end
+    private :teardown_namespaces
 
-    def table_name
-      klass.table_name
+    # Check if namespace is still defined.
+    # It could be already removed if it were inside a model created by Temping.
+    # Since `@models` are teared down first, it means that in such a case all modules that were
+    # inside that model are no longer defined.
+    def namespace_still_defined?(namespace)
+      parent = Object
+      outer_namespace_parts = []
+      namespace.to_s.split("::").each do |part|
+        return false unless parent.const_defined?(part)
+
+        outer_namespace_parts.push(part)
+        parent = outer_namespace_parts.join("::").constantize
+      end
+      true
     end
+    private :namespace_still_defined?
+
+    # Namespace can be removed only if it's still defined and if it was created by Temping,
+    # we use `defined_by_temping?` to indicate the latter.
+    def namespace_removable?(namespace, parts, parent)
+      parent.const_defined?(parts.last) && namespace.defined_by_temping?
+    rescue NoMethodError
+      false
+    end
+    private :namespace_removable?
+
+    # Clean `@namespaces` array by either removing current namespace or replacing it with its
+    # parent.
+    #
+    # Case 1: @namespaces = [A, B, C, D]; index = 3
+    # This is an outer-most module, we just remove it from `@namespaces`.
+    #
+    # Case 2: @namespaces = [A::B, A::B::C, A::D]; index = 1
+    # Once we remove C from A::B::C, it becomes A::B, but we already have A::B, so just remove it.
+    #
+    # Case 3: @namespaces = [A::B, A::D]; index = 1
+    # Once we remove D from A::D, it becomes A, replace A::D with A.
+    def delete_or_trim_in_namespaces(parent, parts, index)
+      is_last_module = parts.length == 1
+      if is_last_module
+        @namespaces.delete_at(index)
+        return
+      end
+
+      parent_already_in_namespaces = @namespaces.include?(parent)
+      if parent_already_in_namespaces
+        @namespaces.delete_at(index)
+        return
+      end
+
+      @namespaces[index] = parent
+    end
+    private :delete_or_trim_in_namespaces
   end
 end

--- a/lib/temping/model_factory.rb
+++ b/lib/temping/model_factory.rb
@@ -1,0 +1,69 @@
+class Temping::ModelFactory
+  DEFAULT_OPTIONS = {temporary: true}
+
+  def initialize(name, namespace, options = {}, &block)
+    @name = name
+    @namespace = namespace
+    @options = options
+    klass.class_eval(&block) if block
+    klass.reset_column_information
+  end
+
+  def klass
+    @klass ||= @namespace.const_get(@name)
+  rescue NameError
+    @klass = build
+  end
+
+  private
+
+  def build
+    Class.new(parent_class_name).tap do |klass|
+      @namespace.const_set(@name, klass)
+      klass.primary_key = @options[:primary_key] || :id
+      create_table(@options)
+      add_methods
+      klass.namespace = @namespace
+    end
+  end
+
+  def parent_class_name
+    @options.fetch(:parent_class, default_parent_class_name)
+  end
+
+  def default_parent_class_name
+    if defined?(ApplicationRecord)
+      ApplicationRecord
+    else
+      ActiveRecord::Base
+    end
+  end
+
+  def create_table(options = {})
+    connection.create_table(table_name, **DEFAULT_OPTIONS.merge(options))
+  end
+
+  def add_methods
+    class << klass
+      attr_accessor :namespace
+
+      def with_columns
+        connection.change_table(table_name) do |table|
+          yield(table)
+        end
+      end
+
+      def table_exists?
+        true
+      end
+    end
+  end
+
+  def connection
+    klass.connection
+  end
+
+  def table_name
+    klass.table_name
+  end
+end

--- a/lib/temping/namespace_factory.rb
+++ b/lib/temping/namespace_factory.rb
@@ -1,0 +1,24 @@
+class Temping::NamespaceFactory
+  def initialize(name)
+    @name = name
+  end
+
+  def klass
+    @klass ||= @name.split("::").reduce(Object) { |parent, name_part| build(parent, name_part) }
+  end
+
+  private
+
+  def build(parent, name_part)
+    parent.const_get(name_part)
+  rescue NameError
+    parent.const_set(
+      name_part,
+      Module.new do
+        def self.defined_by_temping?
+          true
+        end
+      end
+    )
+  end
+end

--- a/spec/temping_spec.rb
+++ b/spec/temping_spec.rb
@@ -6,13 +6,13 @@ TABLE_NOT_EXISTS_REGEX = Regexp.new(
 )
 
 describe Temping do
-  after { Temping.teardown }
-
   let(:is_mysql_or_sqlite) do
     %w[mysql sqlite].any? do |name|
       ActiveRecord::Base.connection.adapter_name.downcase.starts_with?(name)
     end
   end
+
+  after { Temping.teardown }
 
   describe ".create" do
     it "creates and returns an ActiveRecord model" do
@@ -20,6 +20,11 @@ describe Temping do
       expect(post_class).to eq Post
       expect(post_class.table_name).to eq "posts"
       expect(post_class.primary_key).to eq "id"
+    end
+
+    it "allows creating records" do
+      Temping.create(:post)
+      expect { Post.create! }.to change { Post.count }.from(0).to(1)
     end
 
     context "when ApplicationRecord is defined" do
@@ -31,7 +36,7 @@ describe Temping do
 
       it "creates a model that inherits from ApplicationRecord" do
         kitty_class = Temping.create(:kittens)
-        expect(kitty_class.superclass).to eq(ApplicationRecord)
+        expect(kitty_class.superclass).to eq ApplicationRecord
       end
     end
 
@@ -44,7 +49,7 @@ describe Temping do
 
       it "creates a model that inherits from ActiveRecord::Base" do
         gerbil_class = Temping.create(:gerbil)
-        expect(gerbil_class.superclass).to eq(ActiveRecord::Base)
+        expect(gerbil_class.superclass).to eq ActiveRecord::Base
       end
     end
 
@@ -57,19 +62,85 @@ describe Temping do
         end
       end
 
-      after do
-        Object.send(:remove_const, :TestBaseClass)
-      end
+      after { Object.send(:remove_const, :TestBaseClass) }
 
       it "uses the provided parent class option" do
         child_class = Temping.create(:test_child, parent_class: TestBaseClass)
-        expect(child_class.superclass).to eq(TestBaseClass)
-        expect(child_class.new).to be_an(TestBaseClass)
+        expect(child_class.superclass).to eq TestBaseClass
+        expect(child_class.new).to be_a TestBaseClass
       end
 
       it "doesn’t affect other types" do
         gerbil_class = Temping.create(:gerbil)
-        expect(gerbil_class.superclass).to eq(ActiveRecord::Base)
+        expect(gerbil_class.superclass).to eq ActiveRecord::Base
+      end
+    end
+
+    context "with a one level namespace" do
+      subject { Temping.create("people/developers") }
+
+      it "creates a model with the correct namespace" do
+        expect(subject.new).to be_a People::Developer
+      end
+
+      it "creates a table with the correct name" do
+        developer_class = subject
+        expect(developer_class.table_name).to eq "developers"
+        expect(developer_class.primary_key).to eq "id"
+        expect(ActiveRecord::Base.connection.column_exists?(:developers, :id)).to eq true
+      end
+
+      it "allows creating records" do
+        subject
+        expect { People::Developer.create! }.to change { People::Developer.count }.from(0).to(1)
+      end
+    end
+
+    context "with a deep namespace" do
+      subject { Temping.create(:"virtual_object/feeling/emotional/happiness") }
+
+      it "creates a model with the correct namespace" do
+        expect(subject.new).to be_a VirtualObject::Feeling::Emotional::Happiness
+      end
+
+      it "creates a table with the correct name" do
+        expect(subject.table_name).to eq "happinesses"
+        expect(subject.primary_key).to eq "id"
+        expect(ActiveRecord::Base.connection.column_exists?(:happinesses, :id)).to eq true
+      end
+
+      it "allows creating records" do
+        subject
+        expect { VirtualObject::Feeling::Emotional::Happiness.create! }
+          .to change { VirtualObject::Feeling::Emotional::Happiness.count }.from(0).to(1)
+      end
+    end
+
+    context "with a deep namespace, predefined modules, and table prefix" do
+      subject { Temping.create(:"physical_object/vehicle/car/sedan") }
+
+      around do |example|
+        Object.const_set(:PhysicalObject, Module.new)
+        PhysicalObject.const_set(:Vehicle, Module.new)
+        PhysicalObject::Vehicle.const_set(:Car, Module.new do
+          def self.table_name_prefix
+            "custom_prefix_"
+          end
+        end)
+        example.run
+        PhysicalObject::Vehicle.send(:remove_const, :Car)
+        PhysicalObject.send(:remove_const, :Vehicle)
+        Object.send(:remove_const, :PhysicalObject)
+      end
+
+      it "creates a model with the correct namespace" do
+        expect(subject.new).to be_a PhysicalObject::Vehicle::Car::Sedan
+      end
+
+      it "creates a table with the correct name" do
+        expect(subject.table_name).to eq "custom_prefix_sedans"
+        expect(subject.primary_key).to eq "id"
+        expect(ActiveRecord::Base.connection.column_exists?(:custom_prefix_sedans, :id)).to eq true
       end
     end
 
@@ -80,63 +151,59 @@ describe Temping do
     end
 
     it "evaluates block in the model's context" do
-      Temping.create :publication do
-        with_columns do |table|
-          table.string :name
+      Temping.create(:publication) do
+        with_columns do |t|
+          t.string :name
         end
-
         validates :name, presence: true
       end
 
       publication = Publication.new
       expect(publication).to_not be_valid
-      expect(publication.errors.full_messages).to include("Name can't be blank")
+      expect(publication.errors.full_messages).to include "Name can't be blank"
       publication.name = "The New York Times"
       expect(publication).to be_valid
     end
 
     it "silently skips initialization if the constant is already defined" do
-      expect {
-        2.times { Temping.create :dog }
-      }.not_to raise_exception
+      expect { 2.times { Temping.create(:dog) } }.not_to raise_exception
     end
 
     it "returns the model if the constant is already defined" do
       cat = Temping.create(:cat)
-
       expect(Temping.create(:cat)).to eq cat
     end
 
     describe "with_columns" do
       it "creates columns passed in through a block" do
-        Temping.create :comment do
-          with_columns do |table|
-            table.integer :count
-            table.string :headline
-            table.text :body
+        Temping.create(:comment) do
+          with_columns do |t|
+            t.integer :count
+            t.string :headline
+            t.text :body
           end
         end
 
-        expect(Comment.columns.map(&:name)).to include("count", "headline", "body")
+        expect(Comment.columns.map(&:name)).to include "count", "headline", "body"
       end
 
       it "adds new columns if called more than once" do
-        Temping.create :human do
-          with_columns do |table|
-            table.integer :head_count
+        Temping.create(:human) do
+          with_columns do |t|
+            t.integer :head_count
           end
         end
 
-        expect(Human.columns.map(&:name)).to include("head_count")
+        expect(Human.columns.map(&:name)).to include "head_count"
 
-        Temping.create :human do
-          with_columns do |table|
-            table.string :name
-            table.text :body
+        Temping.create(:human) do
+          with_columns do |t|
+            t.string :name
+            t.text :body
           end
         end
 
-        expect(Human.columns.map(&:name)).to include("name", "body")
+        expect(Human.columns.map(&:name)).to include "name", "body"
       end
     end
   end
@@ -146,9 +213,9 @@ describe Temping do
 
     context "with a single model" do
       before do
-        Temping.create :user do
-          with_columns do |table|
-            table.string :email
+        Temping.create(:user) do
+          with_columns do |t|
+            t.string :email
           end
         end
         User.create!
@@ -168,14 +235,55 @@ describe Temping do
       end
     end
 
+    context "with a single model in a one level namespace" do
+      before do
+        Temping.create(:"animal/dog") do
+          with_columns do |t|
+            t.string :name
+          end
+        end
+        Animal::Dog.create!
+      end
+
+      it "undefines the model, module, and deletes the table" do
+        expect(Object.const_defined?(:Animal)).to eq true
+        expect(Object.const_defined?("Animal::Dog")).to eq true
+        expect(ActiveRecord::Base.connection.column_exists?(:dogs, :id)).to eq true
+        subject
+        expect(Object.const_defined?(:Animal)).to eq false
+        expect(Object.const_defined?("Animal::Dog")).to eq false
+        expect { ActiveRecord::Base.connection.column_exists?(:dogs, :id) }
+          .to raise_error ActiveRecord::StatementInvalid, TABLE_NOT_EXISTS_REGEX
+      end
+    end
+
+    context "with a single model in a deep namespace" do
+      before { Temping.create("animal/big/medium_to_large/dog") }
+
+      it "undefines the model, modules, and deletes the table" do
+        expect(Object.const_defined?(:Animal)).to eq true
+        expect(Object.const_defined?("Animal::Big")).to eq true
+        expect(Object.const_defined?("Animal::Big::MediumToLarge")).to eq true
+        expect(Object.const_defined?("Animal::Big::MediumToLarge::Dog")).to eq true
+        expect(ActiveRecord::Base.connection.column_exists?(:dogs, :id)).to eq true
+        subject
+        expect(Object.const_defined?(:Animal)).to eq false
+        expect(Object.const_defined?("Animal::Big")).to eq false
+        expect(Object.const_defined?("Animal::Big::MediumToLarge")).to eq false
+        expect(Object.const_defined?("Animal::Big::MediumToLarge::Dog")).to eq false
+        expect { ActiveRecord::Base.connection.column_exists?(:dogs, :id) }
+          .to raise_error ActiveRecord::StatementInvalid, TABLE_NOT_EXISTS_REGEX
+      end
+    end
+
     context "with two models and references" do
       before do
-        Temping.create :user do
+        Temping.create(:user) do
           has_many :posts
         end
-        Temping.create :posts do
-          with_columns do |table|
-            table.references :user
+        Temping.create(:posts) do
+          with_columns do |t|
+            t.references :user
           end
         end
         User.joins(:posts).to_a
@@ -189,23 +297,83 @@ describe Temping do
           subject
         end
 
-        Temping.create :user do
+        Temping.create(:user) do
           has_many :posts
           has_many :comments, through: :posts
         end
-        Temping.create :posts do
-          with_columns do |table|
-            table.references :user
+        Temping.create(:posts) do
+          with_columns do |t|
+            t.references :user
           end
           has_many :comments
         end
-        Temping.create :comments do
-          with_columns do |table|
-            table.references :post
+        Temping.create(:comments) do
+          with_columns do |t|
+            t.references :post
           end
         end
 
         expect { User.joins(:comments).to_a }.not_to raise_error
+      end
+    end
+
+    context "with three models sharing module-based namespaces" do
+      before do
+        Temping.create("colors/reddish/orange")
+        Temping.create("colors/reddish/red")
+      end
+
+      it "undefines the model, modules, and deletes the table" do
+        expect(Object.const_defined?(:Colors)).to eq true
+        expect(Object.const_defined?("Colors::Reddish")).to eq true
+        expect(Object.const_defined?("Colors::Reddish::Orange")).to eq true
+        expect(Object.const_defined?("Colors::Reddish::Red")).to eq true
+        expect(ActiveRecord::Base.connection.column_exists?(:oranges, :id)).to eq true
+        expect(ActiveRecord::Base.connection.column_exists?(:reds, :id)).to eq true
+        subject
+        expect(Object.const_defined?(:Colors)).to eq false
+        expect(Object.const_defined?("Colors::Reddish")).to eq false
+        expect(Object.const_defined?("Colors::Reddish::Orange")).to eq false
+        expect(Object.const_defined?("Colors::Reddish::Red")).to eq false
+        expect { ActiveRecord::Base.connection.column_exists?(:oranges, :id) }
+          .to raise_error ActiveRecord::StatementInvalid, TABLE_NOT_EXISTS_REGEX
+        expect { ActiveRecord::Base.connection.column_exists?(:reds, :id) }
+          .to raise_error ActiveRecord::StatementInvalid, TABLE_NOT_EXISTS_REGEX
+      end
+    end
+
+    context "with four models sharing class-based namespaces" do
+      before do
+        Temping.create("items/computer")
+        Temping.create("items/computer/mac")
+        Temping.create("items/computer/linux")
+        Temping.create("items/chair")
+      end
+
+      it "undefines the model, modules, and deletes the table" do
+        expect(Object.const_defined?(:Items)).to eq true
+        expect(Object.const_defined?("Items::Computer")).to eq true
+        expect(Object.const_defined?("Items::Computer::Mac")).to eq true
+        expect(Object.const_defined?("Items::Computer::Linux")).to eq true
+        expect(Object.const_defined?("Items::Chair")).to eq true
+        expect(ActiveRecord::Base.connection.column_exists?(:computers, :id)).to eq true
+        expect(ActiveRecord::Base.connection.column_exists?(:computer_macs, :id)).to eq true
+        expect(ActiveRecord::Base.connection.column_exists?(:computer_linuxes, :id)).to eq true
+        expect(ActiveRecord::Base.connection.column_exists?(:chairs, :id)).to eq true
+        subject
+        expect(Object.const_defined?(:Items)).to eq false
+        expect(Object.const_defined?("Items::Computer")).to eq false
+        expect(Object.const_defined?("Items::Computer::Mac")).to eq false
+        expect(Object.const_defined?("Items::Computer::Linux")).to eq false
+        expect(Object.const_defined?("Items::Chair")).to eq false
+        expect { ActiveRecord::Base.connection.column_exists?(:computers, :id) }
+          .to raise_error ActiveRecord::StatementInvalid, TABLE_NOT_EXISTS_REGEX
+        expect { ActiveRecord::Base.connection.column_exists?(:computer_macs, :id) }
+          .to raise_error ActiveRecord::StatementInvalid, TABLE_NOT_EXISTS_REGEX
+        expect { ActiveRecord::Base.connection.column_exists?(:computer_linuxes, :id) }
+          .to raise_error ActiveRecord::StatementInvalid, TABLE_NOT_EXISTS_REGEX
+        expect { ActiveRecord::Base.connection.column_exists?(:chairs, :id) }
+          .to raise_error ActiveRecord::StatementInvalid, TABLE_NOT_EXISTS_REGEX
       end
     end
 
@@ -214,27 +382,27 @@ describe Temping do
       let(:options) { is_mysql_or_sqlite ? {temporary: false} : {} }
 
       before do
-        Temping.create :user, options do
+        Temping.create(:user, options) do
           has_many :posts
           has_many :comments, through: :posts
           has_many :ratings
         end
-        Temping.create :posts, options do
-          with_columns do |table|
-            table.references :user, foreign_key: true
+        Temping.create(:posts, options) do
+          with_columns do |t|
+            t.references :user, foreign_key: true
           end
           belongs_to :user
           has_many :comments
         end
-        Temping.create :comments, options do
-          with_columns do |table|
-            table.references :post, foreign_key: true
+        Temping.create(:comments, options) do
+          with_columns do |t|
+            t.references :post, foreign_key: true
           end
           belongs_to :post
         end
-        Temping.create :ratings, options do
-          with_columns do |table|
-            table.references :user, foreign_key: true
+        Temping.create(:ratings, options) do
+          with_columns do |t|
+            t.references :user, foreign_key: true
           end
           belongs_to :user
         end
@@ -264,6 +432,92 @@ describe Temping do
           .to raise_error ActiveRecord::StatementInvalid, TABLE_NOT_EXISTS_REGEX
       end
     end
+
+    context "with four models, references, foreign keys, deep namespaces, and table prefix" do
+      # MySQL and SQLite don't allow setting foreign keys for temporary tables
+      let(:options) { is_mysql_or_sqlite ? {temporary: false} : {} }
+
+      before do
+        Temping.create(:world)
+        # This syntax is on purpose, to test how it handles modules defined this way.
+        # standard:disable Lint/ConstantDefinitionInBlock, Layout/EmptyLineBetweenDefs
+        module World::Continent; end
+        module World::Continent::Country
+          def self.table_name_prefix
+            "territories_"
+          end
+        end
+        module Establishments; end
+        module Establishments::Shops; end
+        # standard:enable Lint/ConstantDefinitionInBlock, Layout/EmptyLineBetweenDefs
+        Temping.create("world/continent/country/cities", options) do
+          has_many :streets
+          has_many :buildings, through: :streets
+          has_many :groceries
+        end
+        Temping.create(:streets, options) do
+          with_columns do |t|
+            t.references :territories_city, foreign_key: true
+          end
+          belongs_to :city
+          has_many :buildings
+        end
+        Temping.create(:buildings, options) do
+          with_columns do |t|
+            t.references :street, foreign_key: true
+          end
+          belongs_to :street
+        end
+        Temping.create("establishments/shops/groceries", options) do
+          with_columns do |t|
+            t.references :territories_city, foreign_key: true
+          end
+          belongs_to :city
+        end
+      end
+
+      after do
+        Establishments.send(:remove_const, :Shops)
+        Object.send(:remove_const, :Establishments)
+      end
+
+      it "undefines the models, modules created by Temping, and deletes the tables" do
+        expect(Object.const_defined?(:World)).to eq true
+        expect(Object.const_defined?("World::Continent")).to eq true
+        expect(Object.const_defined?("World::Continent::Country")).to eq true
+        expect(Object.const_defined?("World::Continent::Country::City")).to eq true
+        expect(Object.const_defined?(:Street)).to eq true
+        expect(Object.const_defined?(:Building)).to eq true
+        expect(Object.const_defined?(:Establishments)).to eq true
+        expect(Object.const_defined?("Establishments::Shops")).to eq true
+        expect(Object.const_defined?("Establishments::Shops::Grocery")).to eq true
+        expect(ActiveRecord::Base.connection.column_exists?(:worlds, :id)).to eq true
+        expect(ActiveRecord::Base.connection.column_exists?(:territories_cities, :id)).to eq true
+        expect(ActiveRecord::Base.connection.column_exists?(:streets, :id)).to eq true
+        expect(ActiveRecord::Base.connection.column_exists?(:buildings, :id)).to eq true
+        expect(ActiveRecord::Base.connection.column_exists?(:groceries, :id)).to eq true
+        subject
+        expect(Object.const_defined?(:World)).to eq false
+        expect(Object.const_defined?("World::Continent")).to eq false
+        expect(Object.const_defined?("World::Continent::Country")).to eq false
+        expect(Object.const_defined?("World::Continent::Country::City")).to eq false
+        expect(Object.const_defined?(:Street)).to eq false
+        expect(Object.const_defined?(:Building)).to eq false
+        expect(Object.const_defined?(:Establishments)).to eq true
+        expect(Object.const_defined?("Establishments::Shops")).to eq true
+        expect(Object.const_defined?("Establishments::Shops::Grocery")).to eq false
+        expect { ActiveRecord::Base.connection.column_exists?(:worlds, :id) }
+          .to raise_error ActiveRecord::StatementInvalid, TABLE_NOT_EXISTS_REGEX
+        expect { ActiveRecord::Base.connection.column_exists?(:territories_cities, :id) }
+          .to raise_error ActiveRecord::StatementInvalid, TABLE_NOT_EXISTS_REGEX
+        expect { ActiveRecord::Base.connection.column_exists?(:streets, :id) }
+          .to raise_error ActiveRecord::StatementInvalid, TABLE_NOT_EXISTS_REGEX
+        expect { ActiveRecord::Base.connection.column_exists?(:buildings, :id) }
+          .to raise_error ActiveRecord::StatementInvalid, TABLE_NOT_EXISTS_REGEX
+        expect { ActiveRecord::Base.connection.column_exists?(:groceries, :id) }
+          .to raise_error ActiveRecord::StatementInvalid, TABLE_NOT_EXISTS_REGEX
+      end
+    end
   end
 
   describe ".cleanup" do
@@ -271,9 +525,9 @@ describe Temping do
 
     context "with a single model" do
       before do
-        Temping.create :user do
-          with_columns do |table|
-            table.string :email
+        Temping.create(:user) do
+          with_columns do |t|
+            t.string :email
           end
         end
       end
@@ -296,26 +550,28 @@ describe Temping do
       end
     end
 
-    context "with two models, references, and foreign key" do
+    context "with two models, namespaces, references, and foreign key" do
       # MySQL and SQLite don't allow setting foreign keys for temporary tables
       let(:options) { is_mysql_or_sqlite ? {temporary: false} : {} }
 
       before do
-        Temping.create(:user, options)
-        Temping.create(:post, options) do
-          with_columns do |table|
-            table.references :user, foreign_key: true
+        Temping.create("stuff/user", options)
+        Temping.create("stuff/post", options) do
+          with_columns do |t|
+            t.references :user, foreign_key: true
           end
           belongs_to :user, optional: false
         end
       end
 
       it "keeps constants" do
-        expect(Object.const_defined?(:User)).to eq true
-        expect(Object.const_defined?(:Post)).to eq true
+        expect(Object.const_defined?(:Stuff)).to eq true
+        expect(Object.const_defined?("Stuff::User")).to eq true
+        expect(Object.const_defined?("Stuff::Post")).to eq true
         subject
-        expect(Object.const_defined?(:User)).to eq true
-        expect(Object.const_defined?(:Post)).to eq true
+        expect(Object.const_defined?(:Stuff)).to eq true
+        expect(Object.const_defined?("Stuff::User")).to eq true
+        expect(Object.const_defined?("Stuff::Post")).to eq true
       end
 
       it "keeps tables" do
@@ -327,10 +583,11 @@ describe Temping do
       end
 
       it "destroys records" do
-        user = User.create!
-        Post.create!(user: user)
+        user = Stuff::User.create!
+        Stuff::Post.create!(user: user)
         expect { subject }
-          .to change { User.count }.from(1).to(0).and change { Post.count }.from(1).to(0)
+          .to change { Stuff::User.count }.from(1).to(0)
+          .and change { Stuff::Post.count }.from(1).to(0)
       end
     end
   end


### PR DESCRIPTION
Closes feature request #17.

Now if Temping detects you wanted to create a namespace for your model it will create it if it doesn't exist yet or use the existing one. During `.teardown` it will undefine all the modules from the namespace previously created by itself.

A fresh entry in the Readme:
--

Temping supports creating models within namespaces. 
You can do this either by just including the full namespace in the name:

```ruby
Temping.create('animal/cat')

Animal::Cat.create # => <Animal::Cat id: 1>
Animal::Cat.table_name # => "cats"
Animal::Cat # => Animal::Cat(id: integer)
```

Or you can create the module(s) yourself:

```ruby
module Engineers
  def self.table_name_prefix
    "hard_working_"
  end
end
Temping.create('engineers/developers')

Engineers::Developer.create # => <Engineers::Developer id: 1> 
Engineers::Developer.table_name # => "hard_working_developers"
Engineers::Developer # => Engineers::Developer(id: integer)
```

Please note that if you create the modules yourself, Temping will NOT attempt 
to undefine them when you call `Temping.teardown`, it will only undefine the modules 
created by itself:

```ruby 
module Engineers; end
Temping.create('engineers/developers')
Temping.create('animal/cat')

Temping.teardown

Object.const_defined?(:Engineers) # => true
Object.const_defined?(:Animal) # => false
```

Deep namespaces are supported as well:

```ruby 
Temping.create('continents/countries/cities/streets/buildings')

# => Continents::Countries::Cities::Streets::Building(id: integer) 
```