### PR TITLE
Adjust ruby version requirement to 2.2.2 and add 2.2 and 2.3 to CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -77,6 +77,12 @@ jobs:
             rails: '6.0'
           - ruby: '2.4'
             rails: '5.2'
+          - ruby: '2.3'
+            rails: '5.2'
+            skipped_adapters: 'mysql,postgresql' # these adapters don't work well with this setup
+          - ruby: '2.2.10'
+            rails: '5.2'
+            skipped_adapters: 'mysql,postgresql' # these adapters don't work well with this setup
           - ruby: 'jruby'
             rails: '6.1'
           - ruby: 'jruby'
@@ -89,6 +95,7 @@ jobs:
             rails: '6.0'
     env:
       BUNDLE_GEMFILE: gemfiles/activerecord_${{ matrix.rails }}.gemfile
+      SKIPPED_ADAPTERS: ${{ matrix.skipped_adapters }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -100,7 +107,7 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - name: Run tests
-        run: ${{ matrix.env }} bundle exec rake spec
+        run: bundle exec rake spec
       - name: Upload code coverage results as artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,1 +1,1 @@
-ruby_version: 2.0.0
+ruby_version: 2.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ User-visible changes worth mentioning.
 models in the reverse order  - Thanks @gregnavis
 - [#59](https://github.com/jpignata/temping/pull/59): Add support for Ruby 3.0 and above - Thanks @dark-panda
 - [#68](https://github.com/jpignata/temping/pull/68): Add support for Rails 7.0
-- [#69](https://github.com/jpignata/temping/pull/69): Drop support for Ruby below 2.0 and Rails below 5.2
+- [#69](https://github.com/jpignata/temping/pull/69), 
+[#81](https://github.com/jpignata/temping/pull/81): 
+Drop support for Ruby below 2.2.2 and Rails below 5.2
 
 ## 3.10.0 - 2017-09-27
 - Drop support for `mysql`, just test `mysql2`

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ is about using **temporary** tables.
 
 ## Tested Environments
 
-The latest version of this gem is tested with the following interpreters/gems:
+The latest version of this gem is tested with the following setups:
 
 * MRI 3.2 with ActiveRecord 7.0
 * MRI 3.1 with ActiveRecord 7.0, 6.1
@@ -251,7 +251,9 @@ The latest version of this gem is tested with the following interpreters/gems:
 * MRI 2.6 with ActiveRecord 6.1, 6.0
 * MRI 2.5 with ActiveRecord 6.1, 6.0
 * MRI 2.4 with ActiveRecord 5.2
-* JRuby with ActiveRecord 6.1, 6.0 (activerecord-jdbc-adapter)
+* MRI 2.3 with ActiveRecord 5.2 (only SQLite)
+* MRI 2.2 with ActiveRecord 5.2 (only SQLite)
+* JRuby with ActiveRecord 6.1, 6.0 (with activerecord-jdbc-adapter)
 * TruffleRuby with ActiveRecord 7.0, 6.1, 6.0
 
 with the following database systems:

--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,7 @@ namespace :ci do
     task :collate do
       require "simplecov"
       SimpleCov.collate Dir["coverage-resultsets/coverage-*/.resultset.json"] do
-        enable_coverage :branch
+        enable_coverage :branch if respond_to?(:enable_coverage)
         formatter SimpleCov::Formatter::SimpleFormatter
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 require "simplecov"
 SimpleCov.start do
-  enable_coverage :branch
+  enable_coverage :branch if respond_to?(:enable_coverage)
   add_filter "test_config.rb"
 end
 

--- a/spec/test_config.rb
+++ b/spec/test_config.rb
@@ -7,7 +7,8 @@ module TestConfig
     end
 
     def adapter_versions
-      config.keys
+      @adapter_versions ||=
+        config.keys.reject { |key| skipped_adapters.any? { |adapter| key.to_s.include?(adapter) } }
     end
 
     # #current_adapter_version and #current_adapter_version= use an environment variable because
@@ -22,6 +23,11 @@ module TestConfig
     def current_adapter_version=(adapter_version)
       ENV["TEMPING_ADAPTER_VERSION"] = adapter_version
     end
+
+    def skipped_adapters
+      @skipped_adapters ||= ENV["SKIPPED_ADAPTERS"].to_s.downcase.split(/[,:;]/)
+    end
+    private :skipped_adapters
 
     def config
       @config ||= YAML.safe_load(File.read(config_path))

--- a/temping.gemspec
+++ b/temping.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   s.files = ["lib/temping.rb"]
 
-  s.required_ruby_version = ">= 2.0"
+  s.required_ruby_version = ">= 2.2.2"
 
   s.add_dependency "activerecord", ">= 5.2", "< 7.1"
   s.add_dependency "activesupport", ">= 5.2", "< 7.1"

--- a/temping.gemspec
+++ b/temping.gemspec
@@ -16,18 +16,24 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "appraisal"
 
-  if RUBY_PLATFORM.match?(/java/)
-    s.add_development_dependency "activerecord-jdbcsqlite3-adapter", ">= 60.0"
-    s.add_development_dependency "activerecord-jdbcpostgresql-adapter", ">= 60.0"
-    s.add_development_dependency "activerecord-jdbcmysql-adapter", ">= 60.0"
+  skipped_adapters = ENV["SKIPPED_ADAPTERS"].to_s.downcase
+  sqlite_skipped = skipped_adapters.include?("sqlite")
+  postgresql_skipped = skipped_adapters.include?("postgres")
+  mysql_skipped = skipped_adapters.include?("mysql")
+  if RUBY_PLATFORM.include?("java")
+    s.add_development_dependency "activerecord-jdbcsqlite3-adapter", ">= 60.0" unless sqlite_skipped
+    unless postgresql_skipped
+      s.add_development_dependency "activerecord-jdbcpostgresql-adapter", ">= 60.0"
+    end
+    s.add_development_dependency "activerecord-jdbcmysql-adapter", ">= 60.0" unless mysql_skipped
   else
-    s.add_development_dependency "sqlite3", ">= 1.3", "< 2.0"
-    s.add_development_dependency "pg", ">= 1.2", "< 2.0"
-    s.add_development_dependency "mysql2", "~> 0.5"
+    s.add_development_dependency "sqlite3", ">= 1.3", "< 2.0" unless sqlite_skipped
+    s.add_development_dependency "pg", ">= 1.2", "< 2.0" unless postgresql_skipped
+    s.add_development_dependency "mysql2", "~> 0.5" unless mysql_skipped
   end
 
   s.add_development_dependency "rspec", "~> 3.12"
   s.add_development_dependency "rake", "~> 13.0"
-  s.add_development_dependency "simplecov", "~> 0.18"
+  s.add_development_dependency "simplecov", "~> 0.17"
   s.add_development_dependency "standard"
 end


### PR DESCRIPTION
Changes:

1. Add ruby 2.2 and 2.3 to CI. These only work with SQLite however ([mysql fail](https://github.com/ruby/setup-ruby/issues/150#issuecomment-767760333), [postgresql fail](https://github.com/dmytro-savochkin/temping/actions/runs/3405123075/jobs/5662861593)) with the current setup of Github Actions. This is still better than nothing because this at least confirms all the used syntax in the gem works with these versions of ruby.

2. Set minimum requirement version of Ruby to be 2.2.2. This is what [Rails 5.2 specifies](https://github.com/rails/rails/blob/5-2-stable/rails.gemspec) and since it's the lowest version of Rails we support we should just specify the same.
