### PR TITLE
Bump v4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ User-visible changes worth mentioning.
 
 ---
 
+## 4.1.1 - 2023-10-12
+- Fix support for Rails 7.1.x - Thanks @mikeastock
+
+[(full changelog since previous version)](https://github.com/jpignata/temping/compare/v4.1.0...v4.1.1)
+
 ## 4.1.0 - 2023-10-07
 - Add support for Rails 7.1 - Thanks @gregg-platogo
 - Drop support for Ruby below 2.5.0 and Rails below 6.0

--- a/temping.gemspec
+++ b/temping.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "temping"
-  s.version = "4.1.0"
+  s.version = "4.1.1"
   s.authors = ["John Pignata"]
   s.email = "john@pignata.com"
   s.homepage = "http://github.com/jpignata/temping"


### PR DESCRIPTION
Bump version to 4.1.1.
Full changelog can be found here: https://github.com/jpignata/temping/blob/master/CHANGELOG.md