### PR TITLE
Bump v4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ User-visible changes worth mentioning.
 
 ---
 
+## 4.2.0 - 2024-08-10
+- Add support for Rails 7.2 - Thanks @yosiat
+
+[(full changelog since previous version)](https://github.com/jpignata/temping/compare/v4.1.1...v4.2.0)
+
 ## 4.1.1 - 2023-10-12
 - Fix support for Rails 7.1.x - Thanks @mikeastock
 

--- a/temping.gemspec
+++ b/temping.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "temping"
-  s.version = "4.1.1"
+  s.version = "4.2.0"
   s.authors = ["John Pignata"]
   s.email = "john@pignata.com"
   s.homepage = "http://github.com/jpignata/temping"


### PR DESCRIPTION
Bump version to 4.2.0.
Full changelog can be found here: https://github.com/jpignata/temping/blob/master/CHANGELOG.md