### PR TITLE
Support Rails 8.0

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,14 +19,14 @@ jobs:
     name: Run StandardRB linter
     runs-on: ubuntu-latest
     env:
-      BUNDLE_GEMFILE: gemfiles/activerecord_7.1.gemfile
+      BUNDLE_GEMFILE: gemfiles/activerecord_8.0.gemfile
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2'
+          ruby-version: '3.3'
           bundler-cache: true
       - name: Run StandardRB
         id: offenses
@@ -40,7 +40,7 @@ jobs:
           echo '${{ steps.offenses.outputs.LINTER_OFFENSES }}'
       - name: Fail if StandardRB offenses found
         if: steps.offenses.outputs.LINTER_OFFENSES
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: "core.setFailed('StandardRB linter offenses found. Please inspect the details \
                                    of the previous step in the job for more info.')"
@@ -51,6 +51,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - ruby: '3.3'
+            rails: '8.0'
+          - ruby: '3.3'
+            rails: '7.2'
+          - ruby: '3.3'
+            rails: '7.1'
+          - ruby: '3.3'
+            rails: '7.0'
+          - ruby: '3.2'
+            rails: '8.0'
           - ruby: '3.2'
             rails: '7.2'
           - ruby: '3.2'
@@ -91,6 +101,8 @@ jobs:
             rails: '7.0'
           - ruby: 'jruby'
             rails: '6.1'
+          - ruby: 'truffleruby'
+            rails: '8.0'
           - ruby: 'truffleruby'
             rails: '7.2'
           - ruby: 'truffleruby'
@@ -106,7 +118,7 @@ jobs:
       SKIPPED_ADAPTERS: ${{ matrix.skipped_adapters }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup MySQL and PostgreSQL via Docker Compose
         run: docker compose up -d --wait
       - name: Install Ruby
@@ -117,21 +129,22 @@ jobs:
       - name: Run tests
         run: bundle exec rake spec
       - name: Upload code coverage results as artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-ruby-${{ matrix.ruby }}-rails-${{ matrix.rails }}
+          include-hidden-files: true
           path: coverage/.resultset.json
   coverage:
     name: Calculate test coverage
     needs: tests
     runs-on: ubuntu-latest
     env:
-      BUNDLE_GEMFILE: gemfiles/activerecord_7.1.gemfile
+      BUNDLE_GEMFILE: gemfiles/activerecord_8.0.gemfile
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: coverage-resultsets
       - name: Display structure of downloaded files
@@ -139,14 +152,15 @@ jobs:
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2'
+          ruby-version: '3.3'
           bundler-cache: true
       - name: Collate coverage reports
         run: ${{ matrix.env }} bundle exec rake ci:coverage:collate
       - name: Upload total code coverage result as an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-total
+          include-hidden-files: true
           path: coverage/.last_run.json
       - name: Fetch total coverage values from simplecov files
         id: coverage
@@ -159,7 +173,7 @@ jobs:
           echo "Total branch test coverage: ${{ steps.coverage.outputs.COVERAGE_BRANCH }}%"
       - name: Fail if coverage is less than 100%
         if: steps.coverage.outputs.COVERAGE_LINE != 100 || steps.coverage.outputs.COVERAGE_BRANCH != 100
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: "core.setFailed('Please make sure test coverage is 100%. \
                                    Currently: ${{ steps.coverage.outputs.COVERAGE_LINE }}% (line), \

--- a/Appraisals
+++ b/Appraisals
@@ -1,69 +1,39 @@
 appraise "activerecord-6.0" do
   gem "activerecord", "~> 6.0.0"
   gem "activesupport", "~> 6.0.0"
-
-  platforms :ruby, :truffleruby do
-    gem "sqlite3", "~> 1.4.0"
-    gem "pg", "~> 1.5.8"
-    gem "mysql2", "~> 0.5.6"
-  end
+  gem "sqlite3", "~> 1.4", platforms: [:ruby, :truffleruby]
 end
 
 appraise "activerecord-6.1" do
   gem "activerecord", "~> 6.1.0"
   gem "activesupport", "~> 6.1.0"
-
-  platforms :ruby, :truffleruby do
-    gem "sqlite3", "~> 1.4.0"
-    gem "pg", "~> 1.5.8"
-    gem "mysql2", "~> 0.5.6"
-  end
+  gem "sqlite3", "~> 1.4", platforms: [:ruby, :truffleruby]
 end
 
 appraise "activerecord-7.0" do
   gem "activerecord", "~> 7.0.0"
   gem "activesupport", "~> 7.0.0"
+  gem "sqlite3", "~> 1.6", platforms: [:ruby, :truffleruby]
   gem "standard", "~> 1.31"
-
-  platforms :ruby, :truffleruby do
-    gem "sqlite3", "~> 1.6.0"
-    gem "pg", "~> 1.5.8"
-    gem "mysql2", "~> 0.5.6"
-  end
 end
 
 appraise "activerecord-7.1" do
   gem "activerecord", "~> 7.1.0"
   gem "activesupport", "~> 7.1.0"
+  gem "sqlite3", "~> 1.6", platforms: [:ruby, :truffleruby]
   gem "standard", "~> 1.31"
-
-  platforms :ruby, :truffleruby do
-    gem "sqlite3", "~> 1.6.0"
-    gem "pg", "~> 1.5.8"
-    gem "mysql2", "~> 0.5.6"
-  end
 end
 
 appraise "activerecord-7.2" do
   gem "activerecord", "~> 7.2.0"
   gem "activesupport", "~> 7.2.0"
+  gem "sqlite3", "~> 2.0", platforms: [:ruby, :truffleruby]
   gem "standard", "~> 1.31"
-
-  platforms :ruby, :truffleruby do
-    gem "sqlite3", "~> 2.0.0"
-    gem "pg", "~> 1.5.8"
-    gem "mysql2", "~> 0.5.6"
-  end
 end
 
 appraise "activerecord-8.0" do
   gem "activerecord", "~> 8.0.0"
   gem "activesupport", "~> 8.0.0"
+  gem "sqlite3", "~> 2.1", platforms: [:ruby, :truffleruby]
   gem "standard", "~> 1.31"
-
-  platforms :ruby, :truffleruby do
-    gem "sqlite3", "~> 2.2.0"
-    gem "pg", "~> 1.5.8"
-    gem "mysql2", "~> 0.5.6"
-  end
 end

--- a/Appraisals
+++ b/Appraisals
@@ -1,27 +1,69 @@
 appraise "activerecord-6.0" do
-  gem "activerecord", "~> 6.0.6"
-  gem "activesupport", "~> 6.0.6"
+  gem "activerecord", "~> 6.0.0"
+  gem "activesupport", "~> 6.0.0"
+
+  platforms :ruby, :truffleruby do
+    gem "sqlite3", "~> 1.4.0"
+    gem "pg", "~> 1.5.8"
+    gem "mysql2", "~> 0.5.6"
+  end
 end
 
 appraise "activerecord-6.1" do
-  gem "activerecord", "~> 6.1.7"
-  gem "activesupport", "~> 6.1.7"
+  gem "activerecord", "~> 6.1.0"
+  gem "activesupport", "~> 6.1.0"
+
+  platforms :ruby, :truffleruby do
+    gem "sqlite3", "~> 1.4.0"
+    gem "pg", "~> 1.5.8"
+    gem "mysql2", "~> 0.5.6"
+  end
 end
 
 appraise "activerecord-7.0" do
-  gem "activerecord", "~> 7.0.8"
-  gem "activesupport", "~> 7.0.8"
+  gem "activerecord", "~> 7.0.0"
+  gem "activesupport", "~> 7.0.0"
   gem "standard", "~> 1.31"
+
+  platforms :ruby, :truffleruby do
+    gem "sqlite3", "~> 1.6.0"
+    gem "pg", "~> 1.5.8"
+    gem "mysql2", "~> 0.5.6"
+  end
 end
 
 appraise "activerecord-7.1" do
-  gem "activerecord", "~> 7.1.3"
-  gem "activesupport", "~> 7.1.3"
+  gem "activerecord", "~> 7.1.0"
+  gem "activesupport", "~> 7.1.0"
   gem "standard", "~> 1.31"
+
+  platforms :ruby, :truffleruby do
+    gem "sqlite3", "~> 1.6.0"
+    gem "pg", "~> 1.5.8"
+    gem "mysql2", "~> 0.5.6"
+  end
 end
 
 appraise "activerecord-7.2" do
-  gem "activerecord", "~> 7.2"
-  gem "activesupport", "~> 7.2"
+  gem "activerecord", "~> 7.2.0"
+  gem "activesupport", "~> 7.2.0"
   gem "standard", "~> 1.31"
+
+  platforms :ruby, :truffleruby do
+    gem "sqlite3", "~> 2.0.0"
+    gem "pg", "~> 1.5.8"
+    gem "mysql2", "~> 0.5.6"
+  end
+end
+
+appraise "activerecord-8.0" do
+  gem "activerecord", "~> 8.0.0"
+  gem "activesupport", "~> 8.0.0"
+  gem "standard", "~> 1.31"
+
+  platforms :ruby, :truffleruby do
+    gem "sqlite3", "~> 2.2.0"
+    gem "pg", "~> 1.5.8"
+    gem "mysql2", "~> 0.5.6"
+  end
 end

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ ActiveRecord version. This is done with the help of
 For example:
 
 ```shell
-$ BUNDLE_GEMFILE=gemfiles/activerecord_6.1.gemfile rake
+$ BUNDLE_GEMFILE=gemfiles/activerecord_8.0.gemfile rake
 ```
 
 The configuration used to access the databases is stored in

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,14 @@
 source "https://rubygems.org"
 
 gemspec
+
+gem "rspec", "~> 3.13"
+gem "rake", "~> 13.0"
+gem "simplecov", "~> 0.21"
+gem "standard", ">= 0.0.1", "< 2.0"
+
+platforms :jruby do
+  gem "activerecord-jdbcsqlite3-adapter", ">= 60.0"
+  gem "activerecord-jdbcpostgresql-adapter", ">= 60.0"
+  gem "activerecord-jdbcmysql-adapter", ">= 60.0"
+end

--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-gem "rspec", "~> 3.13"
-gem "rake", "~> 13.0"
-gem "simplecov", "~> 0.21"
-gem "standard", ">= 0.0.1", "< 2.0"
-
-platforms :jruby do
-  gem "activerecord-jdbcsqlite3-adapter", ">= 60.0"
-  gem "activerecord-jdbcpostgresql-adapter", ">= 60.0"
-  gem "activerecord-jdbcmysql-adapter", ">= 60.0"
-end

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Code Climate](https://codeclimate.com/github/jpignata/temping.png)](https://codeclimate.com/github/jpignata/temping)
 [![Build Status](https://github.com/jpignata/temping/workflows/checks/badge.svg?branch=master)](https://github.com/jpignata/temping/actions)
-[![Gem Version](https://badge.fury.io/rb/temping.png)](http://badge.fury.io/rb/temping)
+[![Gem Version](https://badge.fury.io/rb/temping.png)](https://badge.fury.io/rb/temping)
 
 Temping allows you to create arbitrary ActiveRecord models backed by a temporary
 SQL table for use in tests. You may need to do something like this if you're
@@ -222,7 +222,7 @@ Temping.create("continents/countries/cities/streets/buildings")
 
 ## Foreign Keys
 
-Temporary tables in [MySQL](https://dev.mysql.com/doc/refman/8.0/en/create-table-foreign-keys.html) 
+Temporary tables in [MySQL](https://dev.mysql.com/doc/refman/9.1/en/create-table-foreign-keys.html) 
 cannot have foreign keys. PostgreSQL doesn't have this limitation.
 
 If you want to use foreign keys with Temping in MySQL you might want to consider 
@@ -244,20 +244,21 @@ is about using **temporary** tables.
 
 The latest version of this gem is tested with the following setups:
 
-* MRI 3.2 with ActiveRecord 7.2, 7.1, 7.0
+* MRI 3.3 with ActiveRecord 8.0, 7.2, 7.1, 7.0
+* MRI 3.2 with ActiveRecord 8.0, 7.2, 7.1, 7.0
 * MRI 3.1 with ActiveRecord 7.2, 7.1, 7.0, 6.1
 * MRI 3.0 with ActiveRecord 7.1, 7.0, 6.1
 * MRI 2.7 with ActiveRecord 7.1, 7.0, 6.1, 6.0
 * MRI 2.6 with ActiveRecord 6.1, 6.0
 * MRI 2.5 with ActiveRecord 6.1, 6.0
 * JRuby with ActiveRecord 7.0, 6.1 (with activerecord-jdbc-adapter)
-* TruffleRuby with ActiveRecord 7.2, 7.1, 7.0, 6.1, 6.0
+* TruffleRuby with ActiveRecord 8.0, 7.2, 7.1, 7.0, 6.1, 6.0
 
 with the following database systems:
 
 * SQLite3
-* MySQL (versions 5.5-9.0)
-* PostgreSQL (versions 10-16)
+* MySQL (versions 5.6-9.1)
+* PostgreSQL (versions 10-17)
 
 If you need to support older versions of Ruby or ActiveRecord you might have to use
 the older versions of this gem (4.0.0 or below).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,20 @@
 version: "3.8"
 services:
+  mysql9.1:
+    image: "mysql:9.1"
+    ports:
+      - "13316:3306"
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: 1
+    healthcheck:
+      test: mysqladmin -u root -h 127.0.0.1 -P 3306 ping
+      interval: 1s
+      timeout: 5s
+      retries: 60
   mysql9.0:
     image: "mysql:9.0"
     ports:
-      - "13316:3306"
+      - "13317:3306"
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: 1
     healthcheck:
@@ -14,7 +25,7 @@ services:
   mysql8.4:
     image: "mysql:8.4"
     ports:
-      - "13317:3306"
+      - "13318:3306"
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: 1
     healthcheck:
@@ -25,7 +36,7 @@ services:
   mysql8.3:
     image: "mysql:8.3"
     ports:
-      - "13318:3306"
+      - "13319:3306"
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: 1
     healthcheck:
@@ -36,7 +47,7 @@ services:
   mysql8.2:
     image: "mysql:8.2"
     ports:
-      - "13319:3306"
+      - "13320:3306"
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: 1
     healthcheck:
@@ -47,7 +58,7 @@ services:
   mysql8.1:
     image: "mysql:8.1"
     ports:
-      - "13320:3306"
+      - "13321:3306"
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: 1
     healthcheck:
@@ -58,7 +69,7 @@ services:
   mysql8.0:
     image: "mysql:8.0.31"
     ports:
-      - "13321:3306"
+      - "13322:3306"
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: 1
     healthcheck:
@@ -69,7 +80,7 @@ services:
   mysql5.7:
     image: "mysql:5.7.40"
     ports:
-      - "13322:3306"
+      - "13323:3306"
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: 1
     healthcheck:
@@ -80,17 +91,6 @@ services:
   mysql5.6:
     image: "mysql:5.6.51"
     ports:
-      - "13323:3306"
-    environment:
-      MYSQL_ALLOW_EMPTY_PASSWORD: 1
-    healthcheck:
-      test: mysqladmin -u root -h 127.0.0.1 -P 3306 ping
-      interval: 1s
-      timeout: 5s
-      retries: 60
-  mysql5.5:
-    image: "mysql:5.5.62"
-    ports:
       - "13324:3306"
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: 1
@@ -99,10 +99,21 @@ services:
       interval: 1s
       timeout: 5s
       retries: 60
+  postgresql17:
+    image: "postgres:17"
+    ports:
+      - "15442:5432"
+    environment:
+      POSTGRES_PASSWORD: password
+    healthcheck:
+      test: pg_isready -U postgres -h 127.0.0.1 -p 5432
+      interval: 1s
+      timeout: 5s
+      retries: 60
   postgresql16:
     image: "postgres:16"
     ports:
-      - "15442:5432"
+      - "15443:5432"
     environment:
       POSTGRES_PASSWORD: password
     healthcheck:
@@ -113,7 +124,7 @@ services:
   postgresql15:
     image: "postgres:15"
     ports:
-      - "15443:5432"
+      - "15444:5432"
     environment:
       POSTGRES_PASSWORD: password
     healthcheck:
@@ -124,7 +135,7 @@ services:
   postgresql14:
     image: "postgres:14"
     ports:
-      - "15444:5432"
+      - "15445:5432"
     environment:
       POSTGRES_PASSWORD: password
     healthcheck:
@@ -135,7 +146,7 @@ services:
   postgresql13:
     image: "postgres:13"
     ports:
-      - "15445:5432"
+      - "15446:5432"
     environment:
       POSTGRES_PASSWORD: password
     healthcheck:
@@ -146,7 +157,7 @@ services:
   postgresql12:
     image: "postgres:12"
     ports:
-      - "15446:5432"
+      - "15447:5432"
     environment:
       POSTGRES_PASSWORD: password
     healthcheck:
@@ -157,7 +168,7 @@ services:
   postgresql11:
     image: "postgres:11"
     ports:
-      - "15447:5432"
+      - "15448:5432"
     environment:
       POSTGRES_PASSWORD: password
     healthcheck:
@@ -168,7 +179,7 @@ services:
   postgresql10:
     image: "postgres:10"
     ports:
-      - "15448:5432"
+      - "15449:5432"
     environment:
       POSTGRES_PASSWORD: password
     healthcheck:

--- a/gemfiles/activerecord_6.0.gemfile
+++ b/gemfiles/activerecord_6.0.gemfile
@@ -2,23 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "rspec", "~> 3.13"
-gem "rake", "~> 13.0"
-gem "simplecov", "~> 0.21"
-gem "standard", ">= 0.0.1", "< 2.0"
 gem "activerecord", "~> 6.0.0"
 gem "activesupport", "~> 6.0.0"
-
-platforms :jruby do
-  gem "activerecord-jdbcsqlite3-adapter", ">= 60.0"
-  gem "activerecord-jdbcpostgresql-adapter", ">= 60.0"
-  gem "activerecord-jdbcmysql-adapter", ">= 60.0"
-end
-
-platforms :ruby, :truffleruby do
-  gem "sqlite3", "~> 1.4.0"
-  gem "pg", "~> 1.5.8"
-  gem "mysql2", "~> 0.5.6"
-end
+gem "sqlite3", "~> 1.4", platforms: [:ruby, :truffleruby]
 
 gemspec path: "../"

--- a/gemfiles/activerecord_6.0.gemfile
+++ b/gemfiles/activerecord_6.0.gemfile
@@ -2,7 +2,23 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 6.0.6"
-gem "activesupport", "~> 6.0.6"
+gem "rspec", "~> 3.13"
+gem "rake", "~> 13.0"
+gem "simplecov", "~> 0.21"
+gem "standard", ">= 0.0.1", "< 2.0"
+gem "activerecord", "~> 6.0.0"
+gem "activesupport", "~> 6.0.0"
+
+platforms :jruby do
+  gem "activerecord-jdbcsqlite3-adapter", ">= 60.0"
+  gem "activerecord-jdbcpostgresql-adapter", ">= 60.0"
+  gem "activerecord-jdbcmysql-adapter", ">= 60.0"
+end
+
+platforms :ruby, :truffleruby do
+  gem "sqlite3", "~> 1.4.0"
+  gem "pg", "~> 1.5.8"
+  gem "mysql2", "~> 0.5.6"
+end
 
 gemspec path: "../"

--- a/gemfiles/activerecord_6.1.gemfile
+++ b/gemfiles/activerecord_6.1.gemfile
@@ -2,23 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "rspec", "~> 3.13"
-gem "rake", "~> 13.0"
-gem "simplecov", "~> 0.21"
-gem "standard", ">= 0.0.1", "< 2.0"
 gem "activerecord", "~> 6.1.0"
 gem "activesupport", "~> 6.1.0"
-
-platforms :jruby do
-  gem "activerecord-jdbcsqlite3-adapter", ">= 60.0"
-  gem "activerecord-jdbcpostgresql-adapter", ">= 60.0"
-  gem "activerecord-jdbcmysql-adapter", ">= 60.0"
-end
-
-platforms :ruby, :truffleruby do
-  gem "sqlite3", "~> 1.4.0"
-  gem "pg", "~> 1.5.8"
-  gem "mysql2", "~> 0.5.6"
-end
+gem "sqlite3", "~> 1.4", platforms: [:ruby, :truffleruby]
 
 gemspec path: "../"

--- a/gemfiles/activerecord_6.1.gemfile
+++ b/gemfiles/activerecord_6.1.gemfile
@@ -2,7 +2,23 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 6.1.7"
-gem "activesupport", "~> 6.1.7"
+gem "rspec", "~> 3.13"
+gem "rake", "~> 13.0"
+gem "simplecov", "~> 0.21"
+gem "standard", ">= 0.0.1", "< 2.0"
+gem "activerecord", "~> 6.1.0"
+gem "activesupport", "~> 6.1.0"
+
+platforms :jruby do
+  gem "activerecord-jdbcsqlite3-adapter", ">= 60.0"
+  gem "activerecord-jdbcpostgresql-adapter", ">= 60.0"
+  gem "activerecord-jdbcmysql-adapter", ">= 60.0"
+end
+
+platforms :ruby, :truffleruby do
+  gem "sqlite3", "~> 1.4.0"
+  gem "pg", "~> 1.5.8"
+  gem "mysql2", "~> 0.5.6"
+end
 
 gemspec path: "../"

--- a/gemfiles/activerecord_7.0.gemfile
+++ b/gemfiles/activerecord_7.0.gemfile
@@ -2,23 +2,9 @@
 
 source "https://rubygems.org"
 
-gem "rspec", "~> 3.13"
-gem "rake", "~> 13.0"
-gem "simplecov", "~> 0.21"
-gem "standard", "~> 1.31"
 gem "activerecord", "~> 7.0.0"
 gem "activesupport", "~> 7.0.0"
-
-platforms :jruby do
-  gem "activerecord-jdbcsqlite3-adapter", ">= 60.0"
-  gem "activerecord-jdbcpostgresql-adapter", ">= 60.0"
-  gem "activerecord-jdbcmysql-adapter", ">= 60.0"
-end
-
-platforms :ruby, :truffleruby do
-  gem "sqlite3", "~> 1.6.0"
-  gem "pg", "~> 1.5.8"
-  gem "mysql2", "~> 0.5.6"
-end
+gem "sqlite3", "~> 1.6", platforms: [:ruby, :truffleruby]
+gem "standard", "~> 1.31"
 
 gemspec path: "../"

--- a/gemfiles/activerecord_7.1.gemfile
+++ b/gemfiles/activerecord_7.1.gemfile
@@ -2,23 +2,9 @@
 
 source "https://rubygems.org"
 
-gem "rspec", "~> 3.13"
-gem "rake", "~> 13.0"
-gem "simplecov", "~> 0.21"
-gem "standard", "~> 1.31"
 gem "activerecord", "~> 7.1.0"
 gem "activesupport", "~> 7.1.0"
-
-platforms :jruby do
-  gem "activerecord-jdbcsqlite3-adapter", ">= 60.0"
-  gem "activerecord-jdbcpostgresql-adapter", ">= 60.0"
-  gem "activerecord-jdbcmysql-adapter", ">= 60.0"
-end
-
-platforms :ruby, :truffleruby do
-  gem "sqlite3", "~> 1.6.0"
-  gem "pg", "~> 1.5.8"
-  gem "mysql2", "~> 0.5.6"
-end
+gem "sqlite3", "~> 1.6", platforms: [:ruby, :truffleruby]
+gem "standard", "~> 1.31"
 
 gemspec path: "../"

--- a/gemfiles/activerecord_7.1.gemfile
+++ b/gemfiles/activerecord_7.1.gemfile
@@ -2,8 +2,23 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 7.1.3"
-gem "activesupport", "~> 7.1.3"
+gem "rspec", "~> 3.13"
+gem "rake", "~> 13.0"
+gem "simplecov", "~> 0.21"
 gem "standard", "~> 1.31"
+gem "activerecord", "~> 7.1.0"
+gem "activesupport", "~> 7.1.0"
+
+platforms :jruby do
+  gem "activerecord-jdbcsqlite3-adapter", ">= 60.0"
+  gem "activerecord-jdbcpostgresql-adapter", ">= 60.0"
+  gem "activerecord-jdbcmysql-adapter", ">= 60.0"
+end
+
+platforms :ruby, :truffleruby do
+  gem "sqlite3", "~> 1.6.0"
+  gem "pg", "~> 1.5.8"
+  gem "mysql2", "~> 0.5.6"
+end
 
 gemspec path: "../"

--- a/gemfiles/activerecord_7.2.gemfile
+++ b/gemfiles/activerecord_7.2.gemfile
@@ -2,23 +2,9 @@
 
 source "https://rubygems.org"
 
-gem "rspec", "~> 3.13"
-gem "rake", "~> 13.0"
-gem "simplecov", "~> 0.21"
-gem "standard", "~> 1.31"
 gem "activerecord", "~> 7.2.0"
 gem "activesupport", "~> 7.2.0"
-
-platforms :jruby do
-  gem "activerecord-jdbcsqlite3-adapter", ">= 60.0"
-  gem "activerecord-jdbcpostgresql-adapter", ">= 60.0"
-  gem "activerecord-jdbcmysql-adapter", ">= 60.0"
-end
-
-platforms :ruby, :truffleruby do
-  gem "sqlite3", "~> 2.0.0"
-  gem "pg", "~> 1.5.8"
-  gem "mysql2", "~> 0.5.6"
-end
+gem "sqlite3", "~> 2.0", platforms: [:ruby, :truffleruby]
+gem "standard", "~> 1.31"
 
 gemspec path: "../"

--- a/gemfiles/activerecord_7.2.gemfile
+++ b/gemfiles/activerecord_7.2.gemfile
@@ -2,8 +2,23 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 7.2"
-gem "activesupport", "~> 7.2"
+gem "rspec", "~> 3.13"
+gem "rake", "~> 13.0"
+gem "simplecov", "~> 0.21"
 gem "standard", "~> 1.31"
+gem "activerecord", "~> 7.2.0"
+gem "activesupport", "~> 7.2.0"
+
+platforms :jruby do
+  gem "activerecord-jdbcsqlite3-adapter", ">= 60.0"
+  gem "activerecord-jdbcpostgresql-adapter", ">= 60.0"
+  gem "activerecord-jdbcmysql-adapter", ">= 60.0"
+end
+
+platforms :ruby, :truffleruby do
+  gem "sqlite3", "~> 2.0.0"
+  gem "pg", "~> 1.5.8"
+  gem "mysql2", "~> 0.5.6"
+end
 
 gemspec path: "../"

--- a/gemfiles/activerecord_8.0.gemfile
+++ b/gemfiles/activerecord_8.0.gemfile
@@ -6,8 +6,8 @@ gem "rspec", "~> 3.13"
 gem "rake", "~> 13.0"
 gem "simplecov", "~> 0.21"
 gem "standard", "~> 1.31"
-gem "activerecord", "~> 7.0.0"
-gem "activesupport", "~> 7.0.0"
+gem "activerecord", "~> 8.0.0"
+gem "activesupport", "~> 8.0.0"
 
 platforms :jruby do
   gem "activerecord-jdbcsqlite3-adapter", ">= 60.0"
@@ -16,7 +16,7 @@ platforms :jruby do
 end
 
 platforms :ruby, :truffleruby do
-  gem "sqlite3", "~> 1.6.0"
+  gem "sqlite3", "~> 2.2.0"
   gem "pg", "~> 1.5.8"
   gem "mysql2", "~> 0.5.6"
 end

--- a/gemfiles/activerecord_8.0.gemfile
+++ b/gemfiles/activerecord_8.0.gemfile
@@ -2,23 +2,9 @@
 
 source "https://rubygems.org"
 
-gem "rspec", "~> 3.13"
-gem "rake", "~> 13.0"
-gem "simplecov", "~> 0.21"
-gem "standard", "~> 1.31"
 gem "activerecord", "~> 8.0.0"
 gem "activesupport", "~> 8.0.0"
-
-platforms :jruby do
-  gem "activerecord-jdbcsqlite3-adapter", ">= 60.0"
-  gem "activerecord-jdbcpostgresql-adapter", ">= 60.0"
-  gem "activerecord-jdbcmysql-adapter", ">= 60.0"
-end
-
-platforms :ruby, :truffleruby do
-  gem "sqlite3", "~> 2.2.0"
-  gem "pg", "~> 1.5.8"
-  gem "mysql2", "~> 0.5.6"
-end
+gem "sqlite3", "~> 2.1", platforms: [:ruby, :truffleruby]
+gem "standard", "~> 1.31"
 
 gemspec path: "../"

--- a/spec/config.default.yml
+++ b/spec/config.default.yml
@@ -1,115 +1,122 @@
 sqlite:
   adapter: sqlite3
   database: ":memory:"
-mysql9.0:
+mysql9.1:
   adapter: mysql2
   host: 127.0.0.1
   database: temping_test
   username: root
   password:
   port: 13316
-mysql8.4:
+mysql9.0:
   adapter: mysql2
   host: 127.0.0.1
   database: temping_test
   username: root
   password:
   port: 13317
-mysql8.3:
+mysql8.4:
   adapter: mysql2
   host: 127.0.0.1
   database: temping_test
   username: root
   password:
   port: 13318
-mysql8.2:
+mysql8.3:
   adapter: mysql2
   host: 127.0.0.1
   database: temping_test
   username: root
   password:
   port: 13319
-mysql8.1:
+mysql8.2:
   adapter: mysql2
   host: 127.0.0.1
   database: temping_test
   username: root
   password:
   port: 13320
-mysql8.0:
+mysql8.1:
   adapter: mysql2
   host: 127.0.0.1
   database: temping_test
   username: root
   password:
   port: 13321
-mysql5.7:
+mysql8.0:
   adapter: mysql2
   host: 127.0.0.1
   database: temping_test
   username: root
   password:
   port: 13322
-mysql5.6:
+mysql5.7:
   adapter: mysql2
   host: 127.0.0.1
   database: temping_test
   username: root
   password:
   port: 13323
-mysql5.5:
+mysql5.6:
   adapter: mysql2
   host: 127.0.0.1
   database: temping_test
   username: root
   password:
   port: 13324
-postgresql16:
+postgresql17:
   adapter: postgresql
   host: 127.0.0.1
   database: temping_test
   username: postgres
   password: password
   port: 15442
-postgresql15:
+postgresql16:
   adapter: postgresql
   host: 127.0.0.1
   database: temping_test
   username: postgres
   password: password
   port: 15443
-postgresql14:
+postgresql15:
   adapter: postgresql
   host: 127.0.0.1
   database: temping_test
   username: postgres
   password: password
   port: 15444
-postgresql13:
+postgresql14:
   adapter: postgresql
   host: 127.0.0.1
   database: temping_test
   username: postgres
   password: password
   port: 15445
-postgresql12:
+postgresql13:
   adapter: postgresql
   host: 127.0.0.1
   database: temping_test
   username: postgres
   password: password
   port: 15446
-postgresql11:
+postgresql12:
   adapter: postgresql
   host: 127.0.0.1
   database: temping_test
   username: postgres
   password: password
   port: 15447
-postgresql10:
+postgresql11:
   adapter: postgresql
   host: 127.0.0.1
   database: temping_test
   username: postgres
   password: password
   port: 15448
+postgresql10:
+  adapter: postgresql
+  host: 127.0.0.1
+  database: temping_test
+  username: postgres
+  password: password
+  port: 15449

--- a/temping.gemspec
+++ b/temping.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |s|
   s.version = "4.2.0"
   s.authors = ["John Pignata"]
   s.email = "john@pignata.com"
-  s.homepage = "http://github.com/jpignata/temping"
+  s.homepage = "https://github.com/jpignata/temping"
   s.summary = "Create temporary table-backed ActiveRecord models for use in tests"
   s.license = "MIT"
 
@@ -11,29 +11,8 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.5"
 
-  s.add_dependency "activerecord", ">= 6.0", "< 7.3"
-  s.add_dependency "activesupport", ">= 6.0", "< 7.3"
+  s.add_dependency "activerecord", ">= 6.0", "< 8.1"
+  s.add_dependency "activesupport", ">= 6.0", "< 8.1"
 
   s.add_development_dependency "appraisal", "~> 2.5"
-
-  skipped_adapters = ENV["SKIPPED_ADAPTERS"].to_s.downcase
-  sqlite_skipped = skipped_adapters.include?("sqlite")
-  postgresql_skipped = skipped_adapters.include?("postgres")
-  mysql_skipped = skipped_adapters.include?("mysql")
-  if RUBY_PLATFORM.include?("java")
-    s.add_development_dependency "activerecord-jdbcsqlite3-adapter", ">= 60.0" unless sqlite_skipped
-    unless postgresql_skipped
-      s.add_development_dependency "activerecord-jdbcpostgresql-adapter", ">= 60.0"
-    end
-    s.add_development_dependency "activerecord-jdbcmysql-adapter", ">= 60.0" unless mysql_skipped
-  else
-    s.add_development_dependency "sqlite3", ">= 1.3", "< 2.0" unless sqlite_skipped
-    s.add_development_dependency "pg", ">= 1.2", "< 2.0" unless postgresql_skipped
-    s.add_development_dependency "mysql2", "~> 0.5" unless mysql_skipped
-  end
-
-  s.add_development_dependency "rspec", "~> 3.13"
-  s.add_development_dependency "rake", "~> 13.0"
-  s.add_development_dependency "simplecov", "~> 0.21"
-  s.add_development_dependency "standard", ">= 0.0.1", "< 2.0"
 end

--- a/temping.gemspec
+++ b/temping.gemspec
@@ -15,4 +15,25 @@ Gem::Specification.new do |s|
   s.add_dependency "activesupport", ">= 6.0", "< 8.1"
 
   s.add_development_dependency "appraisal", "~> 2.5"
+
+  skipped_adapters = ENV["SKIPPED_ADAPTERS"].to_s.downcase
+  sqlite_skipped = skipped_adapters.include?("sqlite")
+  postgresql_skipped = skipped_adapters.include?("postgres")
+  mysql_skipped = skipped_adapters.include?("mysql")
+  if RUBY_PLATFORM.include?("java")
+    s.add_development_dependency "activerecord-jdbcsqlite3-adapter", ">= 60.0" unless sqlite_skipped
+    unless postgresql_skipped
+      s.add_development_dependency "activerecord-jdbcpostgresql-adapter", ">= 60.0"
+    end
+    s.add_development_dependency "activerecord-jdbcmysql-adapter", ">= 60.0" unless mysql_skipped
+  else
+    s.add_development_dependency "sqlite3", ">= 1.3", "< 3.0" unless sqlite_skipped
+    s.add_development_dependency "pg", ">= 1.2", "< 2.0" unless postgresql_skipped
+    s.add_development_dependency "mysql2", "~> 0.5" unless mysql_skipped
+  end
+
+  s.add_development_dependency "rspec", "~> 3.13"
+  s.add_development_dependency "rake", "~> 13.0"
+  s.add_development_dependency "simplecov", "~> 0.21"
+  s.add_development_dependency "standard", ">= 0.0.1", "< 2.0"
 end


### PR DESCRIPTION
*Issue #, if available:* —

*Description of changes:*
* Add support for Rails 8.0
* Add Ruby 3.3, Rails 8.0, PostgreSQL 17, MySQL 9.1 to tests
* Remove MySQL 5.5 from tests as its support ended in 2018 and it’s not supported by Rails 8.0
* Upgrade versions of GitHub actions to fix deprecation warnings

> [!IMPORTANT]  
> The only test failing is [this one](https://github.com/talkable/temping/actions/runs/11778095884/job/32804291774):
> > Please make sure test coverage is 100%. Currently: 100% (line), 97.14% (branch).
>
> Not sure why branch coverage decreased, any suggestions are welcome.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
